### PR TITLE
Minor bug fixes and some Monk animations

### DIFF
--- a/module/autorec.json
+++ b/module/autorec.json
@@ -13200,11 +13200,254 @@
 				"moduleVersion": "1.2.0",
 				"version": 5
 			}
+		},
+		{
+			"id": "60",
+			"label": "Stunning Strike",
+			"levels3d": {
+				"enable": false,
+				"type": "",
+				"data": {
+					"color01": "#000000",
+					"color02": "#000000",
+					"speed": null,
+					"repeat": null,
+					"arc": null,
+					"delay": null,
+					"scale": null,
+					"alpha": null,
+					"gravity": null,
+					"mass": null,
+					"life": null,
+					"emittersize": null,
+					"rate": null,
+					"addexplosion": {
+						"enable": false,
+						"color01": "#000000",
+						"color02": "#000000",
+						"speed": null,
+						"scale": null,
+						"alpha": null,
+						"gravity": null,
+						"mass": null,
+						"life": null,
+						"emittersize": null,
+						"rate": null,
+						"sprite": "modules/levels-3d-preview/assets/particles/dust.webp"
+					},
+					"sprite": "modules/levels-3d-preview/assets/particles/emberssmall.webp"
+				},
+				"secondary": {
+					"enable": false,
+					"data": {}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"isReturning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Bludgeoning/*",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "unarmedstrike",
+					"variant": "magical",
+					"color": "yellow",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "",
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Stunning Strike",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 1
+			}
 		}
 	],
 	"range": [
 		{
-			"id": "60",
+			"id": "61",
 			"label": "Acid Arrow",
 			"levels3d": {
 				"enable": false,
@@ -13421,7 +13664,7 @@
 			}
 		},
 		{
-			"id": "61",
+			"id": "62",
 			"label": "Acid Splash",
 			"levels3d": {
 				"enable": false,
@@ -13638,7 +13881,7 @@
 			}
 		},
 		{
-			"id": "62",
+			"id": "63",
 			"label": "Alchemist's",
 			"levels3d": {
 				"enable": false,
@@ -13855,7 +14098,7 @@
 			}
 		},
 		{
-			"id": "63",
+			"id": "64",
 			"label": "Antimatter Rifle",
 			"levels3d": {
 				"enable": false,
@@ -14071,7 +14314,7 @@
 			}
 		},
 		{
-			"id": "64",
+			"id": "65",
 			"label": "Arcane Burst",
 			"levels3d": {
 				"enable": false,
@@ -14288,7 +14531,7 @@
 			}
 		},
 		{
-			"id": "65",
+			"id": "66",
 			"label": "Beam",
 			"levels3d": {
 				"type": "explosion",
@@ -14475,7 +14718,7 @@
 			}
 		},
 		{
-			"id": "66",
+			"id": "67",
 			"label": "Blood Drain",
 			"levels3d": {
 				"type": "explosion",
@@ -14663,7 +14906,7 @@
 			}
 		},
 		{
-			"id": "67",
+			"id": "68",
 			"label": "Blowgun",
 			"levels3d": {
 				"enable": false,
@@ -14880,7 +15123,7 @@
 			}
 		},
 		{
-			"id": "68",
+			"id": "69",
 			"label": "Bomb",
 			"levels3d": {
 				"enable": false,
@@ -15097,7 +15340,7 @@
 			}
 		},
 		{
-			"id": "69",
+			"id": "70",
 			"label": "Boulder",
 			"levels3d": {
 				"enable": false,
@@ -15314,7 +15557,7 @@
 			}
 		},
 		{
-			"id": "70",
+			"id": "71",
 			"label": "Bow",
 			"levels3d": {
 				"enable": false,
@@ -15532,7 +15775,7 @@
 			}
 		},
 		{
-			"id": "71",
+			"id": "72",
 			"label": "Catapult",
 			"levels3d": {
 				"enable": false,
@@ -15749,7 +15992,7 @@
 			}
 		},
 		{
-			"id": "72",
+			"id": "73",
 			"label": "Chain Lightning",
 			"levels3d": {
 				"enable": false,
@@ -15967,7 +16210,7 @@
 			}
 		},
 		{
-			"id": "73",
+			"id": "74",
 			"label": "Chakram",
 			"levels3d": {
 				"enable": false,
@@ -16184,7 +16427,7 @@
 			}
 		},
 		{
-			"id": "74",
+			"id": "75",
 			"label": "Chaos Bolt",
 			"levels3d": {
 				"enable": false,
@@ -16401,7 +16644,7 @@
 			}
 		},
 		{
-			"id": "75",
+			"id": "76",
 			"label": "Chromatic Orb",
 			"levels3d": {
 				"enable": false,
@@ -16618,7 +16861,7 @@
 			}
 		},
 		{
-			"id": "76",
+			"id": "77",
 			"label": "Contagion",
 			"levels3d": {
 				"type": "explosion",
@@ -16805,7 +17048,7 @@
 			}
 		},
 		{
-			"id": "77",
+			"id": "78",
 			"label": "Crossbow",
 			"levels3d": {
 				"enable": false,
@@ -17023,7 +17266,7 @@
 			}
 		},
 		{
-			"id": "78",
+			"id": "79",
 			"label": "Dart",
 			"levels3d": {
 				"enable": false,
@@ -17241,7 +17484,7 @@
 			}
 		},
 		{
-			"id": "79",
+			"id": "80",
 			"label": "Disintegrate",
 			"levels3d": {
 				"enable": false,
@@ -17458,7 +17701,7 @@
 			}
 		},
 		{
-			"id": "80",
+			"id": "81",
 			"label": "Draining Kiss",
 			"levels3d": {
 				"type": "explosion",
@@ -17646,7 +17889,7 @@
 			}
 		},
 		{
-			"id": "81",
+			"id": "82",
 			"label": "Dynamite",
 			"levels3d": {
 				"enable": false,
@@ -17863,7 +18106,7 @@
 			}
 		},
 		{
-			"id": "82",
+			"id": "83",
 			"label": "Eldritch Blast",
 			"levels3d": {
 				"enable": false,
@@ -18080,7 +18323,7 @@
 			}
 		},
 		{
-			"id": "83",
+			"id": "84",
 			"label": "Feeblemind",
 			"levels3d": {
 				"type": "explosion",
@@ -18265,7 +18508,7 @@
 			}
 		},
 		{
-			"id": "84",
+			"id": "85",
 			"label": "Finger of Death",
 			"levels3d": {
 				"enable": false,
@@ -18482,7 +18725,7 @@
 			}
 		},
 		{
-			"id": "85",
+			"id": "86",
 			"label": "Fire Bolt",
 			"levels3d": {
 				"enable": false,
@@ -18700,7 +18943,7 @@
 			}
 		},
 		{
-			"id": "86",
+			"id": "87",
 			"label": "Fire Ray",
 			"levels3d": {
 				"enable": false,
@@ -18917,7 +19160,7 @@
 			}
 		},
 		{
-			"id": "87",
+			"id": "88",
 			"label": "Fragmentation Grenade",
 			"levels3d": {
 				"enable": false,
@@ -19134,7 +19377,7 @@
 			}
 		},
 		{
-			"id": "88",
+			"id": "89",
 			"label": "Gnomengarde Grenade",
 			"levels3d": {
 				"enable": false,
@@ -19351,7 +19594,7 @@
 			}
 		},
 		{
-			"id": "89",
+			"id": "90",
 			"label": "Grave Bolt",
 			"levels3d": {
 				"type": "explosion",
@@ -19538,7 +19781,7 @@
 			}
 		},
 		{
-			"id": "90",
+			"id": "91",
 			"label": "Grenade",
 			"levels3d": {
 				"enable": false,
@@ -19755,7 +19998,7 @@
 			}
 		},
 		{
-			"id": "91",
+			"id": "92",
 			"label": "Grenade Launcher",
 			"levels3d": {
 				"enable": false,
@@ -19972,7 +20215,7 @@
 			}
 		},
 		{
-			"id": "92",
+			"id": "93",
 			"label": "Guiding Bolt",
 			"levels3d": {
 				"enable": false,
@@ -20190,7 +20433,7 @@
 			}
 		},
 		{
-			"id": "93",
+			"id": "94",
 			"label": "Gun",
 			"levels3d": {
 				"enable": false,
@@ -20407,7 +20650,7 @@
 			}
 		},
 		{
-			"id": "94",
+			"id": "95",
 			"label": "Hurl Flame",
 			"levels3d": {
 				"type": "explosion",
@@ -20594,7 +20837,7 @@
 			}
 		},
 		{
-			"id": "95",
+			"id": "96",
 			"label": "Ice Knife",
 			"levels3d": {
 				"enable": false,
@@ -20811,7 +21054,7 @@
 			}
 		},
 		{
-			"id": "96",
+			"id": "97",
 			"label": "Javelin",
 			"levels3d": {
 				"enable": false,
@@ -21028,7 +21271,7 @@
 			}
 		},
 		{
-			"id": "97",
+			"id": "98",
 			"label": "Laser",
 			"levels3d": {
 				"enable": false,
@@ -21245,7 +21488,7 @@
 			}
 		},
 		{
-			"id": "98",
+			"id": "99",
 			"label": "Life Drain",
 			"levels3d": {
 				"type": "explosion",
@@ -21433,7 +21676,7 @@
 			}
 		},
 		{
-			"id": "99",
+			"id": "100",
 			"label": "Life Transference",
 			"levels3d": {
 				"enable": false,
@@ -21650,7 +21893,7 @@
 			}
 		},
 		{
-			"id": "100",
+			"id": "101",
 			"label": "Lightning Lure",
 			"levels3d": {
 				"enable": false,
@@ -21868,7 +22111,7 @@
 			}
 		},
 		{
-			"id": "101",
+			"id": "102",
 			"label": "Magic Missile",
 			"levels3d": {
 				"enable": false,
@@ -22086,7 +22329,7 @@
 			}
 		},
 		{
-			"id": "102",
+			"id": "103",
 			"label": "Magic Stone",
 			"levels3d": {
 				"enable": false,
@@ -22303,7 +22546,7 @@
 			}
 		},
 		{
-			"id": "103",
+			"id": "104",
 			"label": "Maze",
 			"levels3d": {
 				"enable": false,
@@ -22520,7 +22763,7 @@
 			}
 		},
 		{
-			"id": "104",
+			"id": "105",
 			"label": "Mind Sliver",
 			"levels3d": {
 				"enable": false,
@@ -22738,7 +22981,7 @@
 			}
 		},
 		{
-			"id": "105",
+			"id": "106",
 			"label": "Mind Spike",
 			"levels3d": {
 				"enable": false,
@@ -22955,7 +23198,7 @@
 			}
 		},
 		{
-			"id": "106",
+			"id": "107",
 			"label": "Musket",
 			"levels3d": {
 				"enable": false,
@@ -23172,7 +23415,7 @@
 			}
 		},
 		{
-			"id": "107",
+			"id": "108",
 			"label": "Pistol",
 			"levels3d": {
 				"enable": false,
@@ -23389,7 +23632,7 @@
 			}
 		},
 		{
-			"id": "108",
+			"id": "109",
 			"label": "Poison Spray",
 			"levels3d": {
 				"enable": false,
@@ -23607,7 +23850,7 @@
 			}
 		},
 		{
-			"id": "109",
+			"id": "110",
 			"label": "Ray",
 			"levels3d": {
 				"type": "explosion",
@@ -23792,7 +24035,7 @@
 			}
 		},
 		{
-			"id": "110",
+			"id": "111",
 			"label": "Ray of Enfeeblement",
 			"levels3d": {
 				"enable": false,
@@ -24009,7 +24252,7 @@
 			}
 		},
 		{
-			"id": "111",
+			"id": "112",
 			"label": "Ray of Frost",
 			"levels3d": {
 				"enable": false,
@@ -24227,7 +24470,7 @@
 			}
 		},
 		{
-			"id": "112",
+			"id": "113",
 			"label": "Ray of Sickness",
 			"levels3d": {
 				"enable": false,
@@ -24445,7 +24688,7 @@
 			}
 		},
 		{
-			"id": "113",
+			"id": "114",
 			"label": "Revolver",
 			"levels3d": {
 				"enable": false,
@@ -24662,7 +24905,7 @@
 			}
 		},
 		{
-			"id": "114",
+			"id": "115",
 			"label": "Rifle",
 			"levels3d": {
 				"enable": false,
@@ -24879,7 +25122,7 @@
 			}
 		},
 		{
-			"id": "115",
+			"id": "116",
 			"label": "Rock",
 			"levels3d": {
 				"enable": false,
@@ -25097,7 +25340,7 @@
 			}
 		},
 		{
-			"id": "116",
+			"id": "117",
 			"label": "Scorching Ray",
 			"levels3d": {
 				"enable": false,
@@ -25315,7 +25558,7 @@
 			}
 		},
 		{
-			"id": "117",
+			"id": "118",
 			"label": "Shotgun",
 			"levels3d": {
 				"enable": false,
@@ -25532,7 +25775,7 @@
 			}
 		},
 		{
-			"id": "118",
+			"id": "119",
 			"label": "Siege Boulder",
 			"levels3d": {
 				"enable": false,
@@ -25749,7 +25992,7 @@
 			}
 		},
 		{
-			"id": "119",
+			"id": "120",
 			"label": "Sling",
 			"levels3d": {
 				"enable": false,
@@ -25967,7 +26210,7 @@
 			}
 		},
 		{
-			"id": "120",
+			"id": "121",
 			"label": "Smoke Grenade",
 			"levels3d": {
 				"enable": false,
@@ -26184,7 +26427,7 @@
 			}
 		},
 		{
-			"id": "121",
+			"id": "122",
 			"label": "Sun Blade",
 			"levels3d": {
 				"enable": false,
@@ -26401,7 +26644,7 @@
 			}
 		},
 		{
-			"id": "122",
+			"id": "123",
 			"label": "Tasha's Mind Whip",
 			"levels3d": {
 				"enable": false,
@@ -26619,7 +26862,7 @@
 			}
 		},
 		{
-			"id": "123",
+			"id": "124",
 			"label": "Telepathic Bond",
 			"levels3d": {
 				"enable": false,
@@ -26839,7 +27082,7 @@
 	],
 	"ontoken": [
 		{
-			"id": "124",
+			"id": "125",
 			"label": "Absorb Elements",
 			"levels3d": {
 				"enable": false,
@@ -27036,7 +27279,7 @@
 			}
 		},
 		{
-			"id": "125",
+			"id": "126",
 			"label": "Action Surge",
 			"levels3d": {
 				"enable": false,
@@ -27234,7 +27477,7 @@
 			}
 		},
 		{
-			"id": "126",
+			"id": "127",
 			"label": "Aid",
 			"levels3d": {
 				"enable": false,
@@ -27431,7 +27674,7 @@
 			}
 		},
 		{
-			"id": "127",
+			"id": "128",
 			"label": "Alarm",
 			"levels3d": {
 				"enable": false,
@@ -27628,7 +27871,7 @@
 			}
 		},
 		{
-			"id": "128",
+			"id": "129",
 			"label": "Alter Self",
 			"levels3d": {
 				"enable": false,
@@ -27825,7 +28068,7 @@
 			}
 		},
 		{
-			"id": "129",
+			"id": "130",
 			"label": "Animal Friendship",
 			"levels3d": {
 				"enable": false,
@@ -28022,7 +28265,7 @@
 			}
 		},
 		{
-			"id": "130",
+			"id": "131",
 			"label": "Animal Messenger",
 			"levels3d": {
 				"enable": false,
@@ -28219,7 +28462,7 @@
 			}
 		},
 		{
-			"id": "131",
+			"id": "132",
 			"label": "Animal Shapes",
 			"levels3d": {
 				"type": "explosion",
@@ -28415,7 +28658,7 @@
 			}
 		},
 		{
-			"id": "132",
+			"id": "133",
 			"label": "Animate Dead",
 			"levels3d": {
 				"enable": false,
@@ -28612,7 +28855,7 @@
 			}
 		},
 		{
-			"id": "133",
+			"id": "134",
 			"label": "Arcane Eye",
 			"levels3d": {
 				"enable": false,
@@ -28811,7 +29054,7 @@
 			}
 		},
 		{
-			"id": "134",
+			"id": "135",
 			"label": "Arcane Lock",
 			"levels3d": {
 				"enable": false,
@@ -29008,7 +29251,7 @@
 			}
 		},
 		{
-			"id": "135",
+			"id": "136",
 			"label": "Arcane Recovery",
 			"levels3d": {
 				"enable": false,
@@ -29205,7 +29448,7 @@
 			}
 		},
 		{
-			"id": "136",
+			"id": "137",
 			"label": "Armor of Agathys",
 			"levels3d": {
 				"enable": false,
@@ -29403,7 +29646,7 @@
 			}
 		},
 		{
-			"id": "137",
+			"id": "138",
 			"label": "Arms of Hadar",
 			"levels3d": {
 				"enable": false,
@@ -29600,7 +29843,7 @@
 			}
 		},
 		{
-			"id": "138",
+			"id": "139",
 			"label": "Astral Projection",
 			"levels3d": {
 				"enable": false,
@@ -29797,7 +30040,7 @@
 			}
 		},
 		{
-			"id": "139",
+			"id": "140",
 			"label": "Augury",
 			"levels3d": {
 				"enable": false,
@@ -29994,7 +30237,7 @@
 			}
 		},
 		{
-			"id": "140",
+			"id": "141",
 			"label": "Banishment",
 			"levels3d": {
 				"type": "explosion",
@@ -30188,7 +30431,7 @@
 			}
 		},
 		{
-			"id": "141",
+			"id": "142",
 			"label": "Bardic Inspiration",
 			"levels3d": {
 				"type": "explosion",
@@ -30381,7 +30624,7 @@
 			}
 		},
 		{
-			"id": "142",
+			"id": "143",
 			"label": "Beacon of Hope",
 			"levels3d": {
 				"enable": false,
@@ -30578,7 +30821,7 @@
 			}
 		},
 		{
-			"id": "143",
+			"id": "144",
 			"label": "Beast Sense",
 			"levels3d": {
 				"enable": false,
@@ -30775,7 +31018,7 @@
 			}
 		},
 		{
-			"id": "144",
+			"id": "145",
 			"label": "Bestow Curse",
 			"levels3d": {
 				"enable": false,
@@ -30972,7 +31215,7 @@
 			}
 		},
 		{
-			"id": "145",
+			"id": "146",
 			"label": "Bite",
 			"levels3d": {
 				"enable": false,
@@ -31199,7 +31442,7 @@
 			}
 		},
 		{
-			"id": "146",
+			"id": "147",
 			"label": "Blade Ward",
 			"levels3d": {
 				"type": "explosion",
@@ -31394,7 +31637,7 @@
 			}
 		},
 		{
-			"id": "147",
+			"id": "148",
 			"label": "Blessed Healer",
 			"levels3d": {
 				"type": "explosion",
@@ -31588,7 +31831,7 @@
 			}
 		},
 		{
-			"id": "148",
+			"id": "149",
 			"label": "Blessed Strikes",
 			"levels3d": {
 				"enable": false,
@@ -31785,7 +32028,7 @@
 			}
 		},
 		{
-			"id": "149",
+			"id": "150",
 			"label": "Blight",
 			"levels3d": {
 				"type": "explosion",
@@ -31979,7 +32222,7 @@
 			}
 		},
 		{
-			"id": "150",
+			"id": "151",
 			"label": "Blindness/Deafness",
 			"levels3d": {
 				"enable": false,
@@ -32176,7 +32419,7 @@
 			}
 		},
 		{
-			"id": "151",
+			"id": "152",
 			"label": "Blink",
 			"levels3d": {
 				"enable": false,
@@ -32373,7 +32616,7 @@
 			}
 		},
 		{
-			"id": "152",
+			"id": "153",
 			"label": "Blur",
 			"levels3d": {
 				"enable": false,
@@ -32570,7 +32813,7 @@
 			}
 		},
 		{
-			"id": "153",
+			"id": "154",
 			"label": "Booming Blade",
 			"levels3d": {
 				"type": "explosion",
@@ -32766,7 +33009,7 @@
 			}
 		},
 		{
-			"id": "154",
+			"id": "155",
 			"label": "Cause Fear",
 			"levels3d": {
 				"enable": false,
@@ -32963,7 +33206,7 @@
 			}
 		},
 		{
-			"id": "155",
+			"id": "156",
 			"label": "Channel Divinity",
 			"levels3d": {
 				"enable": false,
@@ -33160,7 +33403,7 @@
 			}
 		},
 		{
-			"id": "156",
+			"id": "157",
 			"label": "Charm",
 			"levels3d": {
 				"type": "explosion",
@@ -33356,7 +33599,7 @@
 			}
 		},
 		{
-			"id": "157",
+			"id": "158",
 			"label": "Charm Person",
 			"levels3d": {
 				"enable": false,
@@ -33553,7 +33796,7 @@
 			}
 		},
 		{
-			"id": "158",
+			"id": "159",
 			"label": "Children of the Night",
 			"levels3d": {
 				"type": "explosion",
@@ -33749,7 +33992,7 @@
 			}
 		},
 		{
-			"id": "159",
+			"id": "160",
 			"label": "Chill Touch",
 			"levels3d": {
 				"enable": false,
@@ -33976,7 +34219,7 @@
 			}
 		},
 		{
-			"id": "160",
+			"id": "161",
 			"label": "Clairvoyance",
 			"levels3d": {
 				"enable": false,
@@ -34173,7 +34416,7 @@
 			}
 		},
 		{
-			"id": "161",
+			"id": "162",
 			"label": "Claw",
 			"levels3d": {
 				"enable": false,
@@ -34370,7 +34613,7 @@
 			}
 		},
 		{
-			"id": "162",
+			"id": "163",
 			"label": "Cleansing Touch",
 			"levels3d": {
 				"enable": false,
@@ -34567,7 +34810,7 @@
 			}
 		},
 		{
-			"id": "163",
+			"id": "164",
 			"label": "Command",
 			"levels3d": {
 				"enable": false,
@@ -34794,7 +35037,7 @@
 			}
 		},
 		{
-			"id": "164",
+			"id": "165",
 			"label": "Commune",
 			"levels3d": {
 				"enable": false,
@@ -34991,7 +35234,7 @@
 			}
 		},
 		{
-			"id": "165",
+			"id": "166",
 			"label": "Commune with Nature",
 			"levels3d": {
 				"type": "explosion",
@@ -35186,7 +35429,7 @@
 			}
 		},
 		{
-			"id": "166",
+			"id": "167",
 			"label": "Compelled Duel",
 			"levels3d": {
 				"enable": false,
@@ -35383,7 +35626,7 @@
 			}
 		},
 		{
-			"id": "167",
+			"id": "168",
 			"label": "Comprehend Languages",
 			"levels3d": {
 				"enable": false,
@@ -35580,7 +35823,7 @@
 			}
 		},
 		{
-			"id": "168",
+			"id": "169",
 			"label": "Compulsion",
 			"levels3d": {
 				"type": "explosion",
@@ -35774,7 +36017,7 @@
 			}
 		},
 		{
-			"id": "169",
+			"id": "170",
 			"label": "Confusion",
 			"levels3d": {
 				"enable": false,
@@ -35971,7 +36214,7 @@
 			}
 		},
 		{
-			"id": "170",
+			"id": "171",
 			"label": "Conjure",
 			"levels3d": {
 				"enable": false,
@@ -36168,7 +36411,7 @@
 			}
 		},
 		{
-			"id": "171",
+			"id": "172",
 			"label": "Constrict",
 			"levels3d": {
 				"enable": false,
@@ -36365,7 +36608,7 @@
 			}
 		},
 		{
-			"id": "172",
+			"id": "173",
 			"label": "Contact Other Plane",
 			"levels3d": {
 				"type": "explosion",
@@ -36560,7 +36803,7 @@
 			}
 		},
 		{
-			"id": "173",
+			"id": "174",
 			"label": "Contingency",
 			"levels3d": {
 				"type": "explosion",
@@ -36754,7 +36997,7 @@
 			}
 		},
 		{
-			"id": "174",
+			"id": "175",
 			"label": "Continual Flame",
 			"levels3d": {
 				"enable": false,
@@ -36951,7 +37194,7 @@
 			}
 		},
 		{
-			"id": "175",
+			"id": "176",
 			"label": "Cordon of Arrows",
 			"levels3d": {
 				"type": "explosion",
@@ -37147,7 +37390,7 @@
 			}
 		},
 		{
-			"id": "176",
+			"id": "177",
 			"label": "Countercharm",
 			"levels3d": {
 				"enable": false,
@@ -37344,7 +37587,7 @@
 			}
 		},
 		{
-			"id": "177",
+			"id": "178",
 			"label": "Counterspell",
 			"levels3d": {
 				"enable": false,
@@ -37541,7 +37784,7 @@
 			}
 		},
 		{
-			"id": "178",
+			"id": "179",
 			"label": "Create Food and Water",
 			"levels3d": {
 				"enable": false,
@@ -37738,7 +37981,7 @@
 			}
 		},
 		{
-			"id": "179",
+			"id": "180",
 			"label": "Create Undead",
 			"levels3d": {
 				"type": "explosion",
@@ -37932,7 +38175,7 @@
 			}
 		},
 		{
-			"id": "180",
+			"id": "181",
 			"label": "Crown of Madness",
 			"levels3d": {
 				"enable": false,
@@ -38129,7 +38372,7 @@
 			}
 		},
 		{
-			"id": "181",
+			"id": "182",
 			"label": "Cure Wounds",
 			"levels3d": {
 				"enable": false,
@@ -38357,7 +38600,7 @@
 			}
 		},
 		{
-			"id": "182",
+			"id": "183",
 			"label": "Dancing Lights",
 			"levels3d": {
 				"type": "explosion",
@@ -38553,7 +38796,7 @@
 			}
 		},
 		{
-			"id": "183",
+			"id": "184",
 			"label": "Darkvision",
 			"levels3d": {
 				"enable": false,
@@ -38751,7 +38994,7 @@
 			}
 		},
 		{
-			"id": "184",
+			"id": "185",
 			"label": "Death Ward",
 			"levels3d": {
 				"enable": false,
@@ -38948,7 +39191,7 @@
 			}
 		},
 		{
-			"id": "185",
+			"id": "186",
 			"label": "Defense Roll",
 			"levels3d": {
 				"type": "explosion",
@@ -39142,7 +39385,7 @@
 			}
 		},
 		{
-			"id": "186",
+			"id": "187",
 			"label": "Detect Thoughts",
 			"levels3d": {
 				"enable": false,
@@ -39339,7 +39582,7 @@
 			}
 		},
 		{
-			"id": "187",
+			"id": "188",
 			"label": "Disguise Self",
 			"levels3d": {
 				"enable": false,
@@ -39536,7 +39779,7 @@
 			}
 		},
 		{
-			"id": "188",
+			"id": "189",
 			"label": "Dispel Evil and Good",
 			"levels3d": {
 				"type": "explosion",
@@ -39730,7 +39973,7 @@
 			}
 		},
 		{
-			"id": "189",
+			"id": "190",
 			"label": "Dispel Magic",
 			"levels3d": {
 				"enable": false,
@@ -39927,7 +40170,7 @@
 			}
 		},
 		{
-			"id": "190",
+			"id": "191",
 			"label": "Dissonant Whispers",
 			"levels3d": {
 				"enable": false,
@@ -40124,7 +40367,7 @@
 			}
 		},
 		{
-			"id": "191",
+			"id": "192",
 			"label": "Divination",
 			"levels3d": {
 				"enable": false,
@@ -40321,7 +40564,7 @@
 			}
 		},
 		{
-			"id": "192",
+			"id": "193",
 			"label": "Divine Favor",
 			"levels3d": {
 				"enable": false,
@@ -40518,7 +40761,7 @@
 			}
 		},
 		{
-			"id": "193",
+			"id": "194",
 			"label": "Divine Intervention",
 			"levels3d": {
 				"enable": false,
@@ -40715,7 +40958,7 @@
 			}
 		},
 		{
-			"id": "194",
+			"id": "195",
 			"label": "Divine Smite",
 			"levels3d": {
 				"enable": false,
@@ -40912,7 +41155,7 @@
 			}
 		},
 		{
-			"id": "195",
+			"id": "196",
 			"label": "Divine Strike",
 			"levels3d": {
 				"enable": false,
@@ -41109,7 +41352,7 @@
 			}
 		},
 		{
-			"id": "196",
+			"id": "197",
 			"label": "Divine Word",
 			"levels3d": {
 				"type": "explosion",
@@ -41303,7 +41546,7 @@
 			}
 		},
 		{
-			"id": "197",
+			"id": "198",
 			"label": "Dominate",
 			"levels3d": {
 				"enable": false,
@@ -41500,7 +41743,7 @@
 			}
 		},
 		{
-			"id": "198",
+			"id": "199",
 			"label": "Dream",
 			"levels3d": {
 				"enable": false,
@@ -41697,7 +41940,7 @@
 			}
 		},
 		{
-			"id": "199",
+			"id": "200",
 			"label": "Dream of the Blue Veil",
 			"levels3d": {
 				"enable": false,
@@ -41894,7 +42137,7 @@
 			}
 		},
 		{
-			"id": "200",
+			"id": "201",
 			"label": "Druidcraft",
 			"levels3d": {
 				"enable": false,
@@ -42092,7 +42335,7 @@
 			}
 		},
 		{
-			"id": "201",
+			"id": "202",
 			"label": "Eldritch Smite",
 			"levels3d": {
 				"enable": false,
@@ -42290,7 +42533,7 @@
 			}
 		},
 		{
-			"id": "202",
+			"id": "203",
 			"label": "Elemental Weapon",
 			"levels3d": {
 				"enable": false,
@@ -42487,7 +42730,7 @@
 			}
 		},
 		{
-			"id": "203",
+			"id": "204",
 			"label": "Encode Thoughts",
 			"levels3d": {
 				"enable": false,
@@ -42686,7 +42929,7 @@
 			}
 		},
 		{
-			"id": "204",
+			"id": "205",
 			"label": "Enhance Ability",
 			"levels3d": {
 				"enable": false,
@@ -42914,7 +43157,7 @@
 			}
 		},
 		{
-			"id": "205",
+			"id": "206",
 			"label": "Enlarge/Reduce",
 			"levels3d": {
 				"type": "explosion",
@@ -43110,7 +43353,7 @@
 			}
 		},
 		{
-			"id": "206",
+			"id": "207",
 			"label": "Ensnaring Strike",
 			"levels3d": {
 				"enable": false,
@@ -43308,7 +43551,7 @@
 			}
 		},
 		{
-			"id": "207",
+			"id": "208",
 			"label": "Enthrall",
 			"levels3d": {
 				"enable": false,
@@ -43506,7 +43749,7 @@
 			}
 		},
 		{
-			"id": "208",
+			"id": "209",
 			"label": "Etherealness",
 			"levels3d": {
 				"enable": false,
@@ -43703,7 +43946,7 @@
 			}
 		},
 		{
-			"id": "209",
+			"id": "210",
 			"label": "Euphoria Breath",
 			"levels3d": {
 				"type": "explosion",
@@ -43897,7 +44140,7 @@
 			}
 		},
 		{
-			"id": "210",
+			"id": "211",
 			"label": "Expeditious Retreat",
 			"levels3d": {
 				"enable": false,
@@ -44125,7 +44368,7 @@
 			}
 		},
 		{
-			"id": "211",
+			"id": "212",
 			"levels3d": {
 				"type": "explosion",
 				"data": {
@@ -44322,7 +44565,7 @@
 			}
 		},
 		{
-			"id": "212",
+			"id": "213",
 			"label": "Eyebite",
 			"levels3d": {
 				"type": "explosion",
@@ -44516,7 +44759,7 @@
 			}
 		},
 		{
-			"id": "213",
+			"id": "214",
 			"label": "Faerie Fire",
 			"levels3d": {
 				"enable": false,
@@ -44713,7 +44956,7 @@
 			}
 		},
 		{
-			"id": "214",
+			"id": "215",
 			"label": "False Life",
 			"levels3d": {
 				"enable": false,
@@ -44910,7 +45153,7 @@
 			}
 		},
 		{
-			"id": "215",
+			"id": "216",
 			"label": "Feather Fall",
 			"levels3d": {
 				"enable": false,
@@ -45107,7 +45350,7 @@
 			}
 		},
 		{
-			"id": "216",
+			"id": "217",
 			"label": "Feign Death",
 			"levels3d": {
 				"enable": false,
@@ -45304,7 +45547,7 @@
 			}
 		},
 		{
-			"id": "217",
+			"id": "218",
 			"label": "Find Familiar",
 			"levels3d": {
 				"enable": false,
@@ -45501,7 +45744,7 @@
 			}
 		},
 		{
-			"id": "218",
+			"id": "219",
 			"label": "Find Steed",
 			"levels3d": {
 				"enable": false,
@@ -45698,7 +45941,7 @@
 			}
 		},
 		{
-			"id": "219",
+			"id": "220",
 			"label": "Find the Path",
 			"levels3d": {
 				"enable": false,
@@ -45895,7 +46138,7 @@
 			}
 		},
 		{
-			"id": "220",
+			"id": "221",
 			"label": "Find Traps",
 			"levels3d": {
 				"enable": false,
@@ -46093,7 +46336,7 @@
 			}
 		},
 		{
-			"id": "221",
+			"id": "222",
 			"label": "Flame Arrows",
 			"levels3d": {
 				"enable": false,
@@ -46290,7 +46533,7 @@
 			}
 		},
 		{
-			"id": "222",
+			"id": "223",
 			"label": "Flame Blade",
 			"levels3d": {
 				"type": "explosion",
@@ -46502,7 +46745,7 @@
 			}
 		},
 		{
-			"id": "223",
+			"id": "224",
 			"label": "Flash of Genius",
 			"levels3d": {
 				"enable": false,
@@ -46699,7 +46942,7 @@
 			}
 		},
 		{
-			"id": "224",
+			"id": "225",
 			"label": "Flesh to Stone",
 			"levels3d": {
 				"type": "explosion",
@@ -46895,7 +47138,7 @@
 			}
 		},
 		{
-			"id": "225",
+			"id": "226",
 			"label": "Floating Disk",
 			"levels3d": {
 				"enable": false,
@@ -47092,7 +47335,7 @@
 			}
 		},
 		{
-			"id": "226",
+			"id": "227",
 			"label": "Fly",
 			"levels3d": {
 				"enable": false,
@@ -47289,7 +47532,7 @@
 			}
 		},
 		{
-			"id": "227",
+			"id": "228",
 			"label": "Flyby",
 			"levels3d": {
 				"type": "explosion",
@@ -47483,7 +47726,7 @@
 			}
 		},
 		{
-			"id": "228",
+			"id": "229",
 			"label": "Foresight",
 			"levels3d": {
 				"enable": false,
@@ -47683,7 +47926,7 @@
 			}
 		},
 		{
-			"id": "229",
+			"id": "230",
 			"label": "Freedom of Movement",
 			"levels3d": {
 				"enable": false,
@@ -47880,7 +48123,7 @@
 			}
 		},
 		{
-			"id": "230",
+			"id": "231",
 			"label": "Friends",
 			"levels3d": {
 				"enable": false,
@@ -48079,7 +48322,7 @@
 			}
 		},
 		{
-			"id": "231",
+			"id": "232",
 			"label": "Frightful Presence",
 			"levels3d": {
 				"enable": false,
@@ -48276,7 +48519,7 @@
 			}
 		},
 		{
-			"id": "232",
+			"id": "233",
 			"label": "Frostbite",
 			"levels3d": {
 				"enable": false,
@@ -48474,7 +48717,7 @@
 			}
 		},
 		{
-			"id": "233",
+			"id": "234",
 			"label": "Gaseous Form",
 			"levels3d": {
 				"enable": false,
@@ -48671,7 +48914,7 @@
 			}
 		},
 		{
-			"id": "234",
+			"id": "235",
 			"label": "Gate",
 			"levels3d": {
 				"enable": false,
@@ -48868,7 +49111,7 @@
 			}
 		},
 		{
-			"id": "235",
+			"id": "236",
 			"label": "Gaze",
 			"levels3d": {
 				"type": "explosion",
@@ -49064,7 +49307,7 @@
 			}
 		},
 		{
-			"id": "236",
+			"id": "237",
 			"label": "Geas",
 			"levels3d": {
 				"type": "explosion",
@@ -49259,7 +49502,7 @@
 			}
 		},
 		{
-			"id": "237",
+			"id": "238",
 			"label": "Gentle Repose",
 			"levels3d": {
 				"enable": false,
@@ -49456,7 +49699,7 @@
 			}
 		},
 		{
-			"id": "238",
+			"id": "239",
 			"label": "Giant Insect",
 			"levels3d": {
 				"type": "explosion",
@@ -49652,7 +49895,7 @@
 			}
 		},
 		{
-			"id": "239",
+			"id": "240",
 			"label": "Glare",
 			"levels3d": {
 				"type": "explosion",
@@ -49848,7 +50091,7 @@
 			}
 		},
 		{
-			"id": "240",
+			"id": "241",
 			"label": "Glyph of Warding",
 			"levels3d": {
 				"enable": false,
@@ -50045,7 +50288,7 @@
 			}
 		},
 		{
-			"id": "241",
+			"id": "242",
 			"label": "Goodberry",
 			"levels3d": {
 				"enable": false,
@@ -50242,7 +50485,7 @@
 			}
 		},
 		{
-			"id": "242",
+			"id": "243",
 			"label": "Gore",
 			"levels3d": {
 				"enable": false,
@@ -50439,7 +50682,7 @@
 			}
 		},
 		{
-			"id": "243",
+			"id": "244",
 			"label": "Grasping Vine",
 			"levels3d": {
 				"type": "explosion",
@@ -50634,7 +50877,7 @@
 			}
 		},
 		{
-			"id": "244",
+			"id": "245",
 			"label": "Green-Flame Blade",
 			"levels3d": {
 				"type": "explosion",
@@ -50846,7 +51089,7 @@
 			}
 		},
 		{
-			"id": "245",
+			"id": "246",
 			"label": "Guardian of Faith",
 			"levels3d": {
 				"type": "explosion",
@@ -51042,7 +51285,7 @@
 			}
 		},
 		{
-			"id": "246",
+			"id": "247",
 			"label": "Guidance",
 			"levels3d": {
 				"type": "explosion",
@@ -51235,7 +51478,7 @@
 			}
 		},
 		{
-			"id": "247",
+			"id": "248",
 			"label": "Gust",
 			"levels3d": {
 				"type": "explosion",
@@ -51429,7 +51672,7 @@
 			}
 		},
 		{
-			"id": "248",
+			"id": "249",
 			"label": "Hail of Thorns",
 			"levels3d": {
 				"enable": false,
@@ -51627,7 +51870,7 @@
 			}
 		},
 		{
-			"id": "249",
+			"id": "250",
 			"label": "Harm",
 			"levels3d": {
 				"enable": false,
@@ -51824,7 +52067,7 @@
 			}
 		},
 		{
-			"id": "250",
+			"id": "251",
 			"label": "Haste",
 			"levels3d": {
 				"enable": false,
@@ -52021,7 +52264,7 @@
 			}
 		},
 		{
-			"id": "251",
+			"id": "252",
 			"label": "Heal",
 			"levels3d": {
 				"enable": false,
@@ -52225,7 +52468,7 @@
 			}
 		},
 		{
-			"id": "252",
+			"id": "253",
 			"label": "Healing Touch",
 			"levels3d": {
 				"type": "explosion",
@@ -52421,7 +52664,7 @@
 			}
 		},
 		{
-			"id": "253",
+			"id": "254",
 			"label": "Healing Word",
 			"levels3d": {
 				"enable": false,
@@ -52647,7 +52890,7 @@
 			}
 		},
 		{
-			"id": "254",
+			"id": "255",
 			"label": "Heat Metal",
 			"levels3d": {
 				"enable": false,
@@ -52844,7 +53087,7 @@
 			}
 		},
 		{
-			"id": "255",
+			"id": "256",
 			"label": "Hellish Rebuke",
 			"levels3d": {
 				"enable": false,
@@ -53041,7 +53284,7 @@
 			}
 		},
 		{
-			"id": "256",
+			"id": "257",
 			"label": "Heroes' Feast",
 			"levels3d": {
 				"enable": false,
@@ -53239,7 +53482,7 @@
 			}
 		},
 		{
-			"id": "257",
+			"id": "258",
 			"label": "Heroism",
 			"levels3d": {
 				"enable": false,
@@ -53436,7 +53679,7 @@
 			}
 		},
 		{
-			"id": "258",
+			"id": "259",
 			"label": "Hex",
 			"levels3d": {
 				"enable": false,
@@ -53633,7 +53876,7 @@
 			}
 		},
 		{
-			"id": "259",
+			"id": "260",
 			"label": "Hideous Laughter",
 			"levels3d": {
 				"enable": false,
@@ -53834,7 +54077,7 @@
 			}
 		},
 		{
-			"id": "260",
+			"id": "261",
 			"label": "Hold Monster",
 			"levels3d": {
 				"enable": false,
@@ -54031,7 +54274,7 @@
 			}
 		},
 		{
-			"id": "261",
+			"id": "262",
 			"label": "Hold Person",
 			"levels3d": {
 				"enable": false,
@@ -54229,7 +54472,7 @@
 			}
 		},
 		{
-			"id": "262",
+			"id": "263",
 			"label": "Horrifying Visage",
 			"levels3d": {
 				"type": "explosion",
@@ -54425,7 +54668,7 @@
 			}
 		},
 		{
-			"id": "263",
+			"id": "264",
 			"label": "Hunter's Mark",
 			"levels3d": {
 				"enable": false,
@@ -54652,7 +54895,7 @@
 			}
 		},
 		{
-			"id": "264",
+			"id": "265",
 			"label": "Identify",
 			"levels3d": {
 				"enable": false,
@@ -54849,7 +55092,7 @@
 			}
 		},
 		{
-			"id": "265",
+			"id": "266",
 			"label": "Illusory Script",
 			"levels3d": {
 				"enable": false,
@@ -55046,7 +55289,7 @@
 			}
 		},
 		{
-			"id": "266",
+			"id": "267",
 			"label": "Immolation",
 			"levels3d": {
 				"enable": false,
@@ -55243,7 +55486,7 @@
 			}
 		},
 		{
-			"id": "267",
+			"id": "268",
 			"label": "Imprisonment",
 			"levels3d": {
 				"enable": false,
@@ -55440,7 +55683,7 @@
 			}
 		},
 		{
-			"id": "268",
+			"id": "269",
 			"label": "Infestation",
 			"levels3d": {
 				"enable": false,
@@ -55643,7 +55886,7 @@
 			}
 		},
 		{
-			"id": "269",
+			"id": "270",
 			"label": "Inflict Wounds",
 			"levels3d": {
 				"enable": false,
@@ -55840,7 +56083,7 @@
 			}
 		},
 		{
-			"id": "270",
+			"id": "271",
 			"label": "Intellect Fortress",
 			"levels3d": {
 				"enable": false,
@@ -56037,7 +56280,7 @@
 			}
 		},
 		{
-			"id": "271",
+			"id": "272",
 			"label": "Invisibility",
 			"levels3d": {
 				"enable": false,
@@ -56264,7 +56507,7 @@
 			}
 		},
 		{
-			"id": "272",
+			"id": "273",
 			"label": "Irresistible Dance",
 			"levels3d": {
 				"enable": false,
@@ -56461,7 +56704,7 @@
 			}
 		},
 		{
-			"id": "273",
+			"id": "274",
 			"label": "Jump",
 			"levels3d": {
 				"enable": false,
@@ -56689,7 +56932,7 @@
 			}
 		},
 		{
-			"id": "274",
+			"id": "275",
 			"label": "Knock",
 			"levels3d": {
 				"enable": false,
@@ -56886,7 +57129,7 @@
 			}
 		},
 		{
-			"id": "275",
+			"id": "276",
 			"label": "Lay on Hands",
 			"levels3d": {
 				"enable": false,
@@ -57083,7 +57326,7 @@
 			}
 		},
 		{
-			"id": "276",
+			"id": "277",
 			"label": "Legend Lore",
 			"levels3d": {
 				"type": "explosion",
@@ -57279,7 +57522,7 @@
 			}
 		},
 		{
-			"id": "277",
+			"id": "278",
 			"label": "Levitate",
 			"levels3d": {
 				"enable": false,
@@ -57476,7 +57719,7 @@
 			}
 		},
 		{
-			"id": "278",
+			"id": "279",
 			"label": "Light",
 			"levels3d": {
 				"enable": false,
@@ -57674,7 +57917,7 @@
 			}
 		},
 		{
-			"id": "279",
+			"id": "280",
 			"label": "Lightning Arrow",
 			"levels3d": {
 				"enable": false,
@@ -57871,7 +58114,7 @@
 			}
 		},
 		{
-			"id": "280",
+			"id": "281",
 			"label": "Locate",
 			"levels3d": {
 				"enable": false,
@@ -58068,7 +58311,7 @@
 			}
 		},
 		{
-			"id": "281",
+			"id": "282",
 			"label": "Longstrider",
 			"levels3d": {
 				"enable": false,
@@ -58296,7 +58539,7 @@
 			}
 		},
 		{
-			"id": "282",
+			"id": "283",
 			"label": "Mage Hand",
 			"levels3d": {
 				"enable": false,
@@ -58494,7 +58737,7 @@
 			}
 		},
 		{
-			"id": "283",
+			"id": "284",
 			"label": "Magic Aura",
 			"levels3d": {
 				"enable": false,
@@ -58691,7 +58934,7 @@
 			}
 		},
 		{
-			"id": "284",
+			"id": "285",
 			"label": "Magic Mouth",
 			"levels3d": {
 				"enable": false,
@@ -58888,7 +59131,7 @@
 			}
 		},
 		{
-			"id": "285",
+			"id": "286",
 			"label": "Magic Weapon",
 			"levels3d": {
 				"enable": false,
@@ -59085,7 +59328,7 @@
 			}
 		},
 		{
-			"id": "286",
+			"id": "287",
 			"label": "Meld into Stone",
 			"levels3d": {
 				"enable": false,
@@ -59284,7 +59527,7 @@
 			}
 		},
 		{
-			"id": "287",
+			"id": "288",
 			"label": "Mending",
 			"levels3d": {
 				"enable": false,
@@ -59483,7 +59726,7 @@
 			}
 		},
 		{
-			"id": "288",
+			"id": "289",
 			"label": "Message",
 			"levels3d": {
 				"enable": false,
@@ -59681,7 +59924,7 @@
 			}
 		},
 		{
-			"id": "289",
+			"id": "290",
 			"label": "Metamagic",
 			"levels3d": {
 				"enable": false,
@@ -59878,7 +60121,7 @@
 			}
 		},
 		{
-			"id": "290",
+			"id": "291",
 			"label": "Mind Blank",
 			"levels3d": {
 				"type": "explosion",
@@ -60075,7 +60318,7 @@
 			}
 		},
 		{
-			"id": "291",
+			"id": "292",
 			"label": "Mirror Image",
 			"levels3d": {
 				"enable": false,
@@ -60272,7 +60515,7 @@
 			}
 		},
 		{
-			"id": "292",
+			"id": "293",
 			"label": "Mislead",
 			"levels3d": {
 				"type": "explosion",
@@ -60468,7 +60711,7 @@
 			}
 		},
 		{
-			"id": "293",
+			"id": "294",
 			"label": "Modify Memory",
 			"levels3d": {
 				"type": "explosion",
@@ -60663,7 +60906,7 @@
 			}
 		},
 		{
-			"id": "294",
+			"id": "295",
 			"label": "Mold Earth",
 			"levels3d": {
 				"enable": false,
@@ -60862,7 +61105,7 @@
 			}
 		},
 		{
-			"id": "295",
+			"id": "296",
 			"label": "Net",
 			"levels3d": {
 				"enable": false,
@@ -61061,7 +61304,7 @@
 			}
 		},
 		{
-			"id": "296",
+			"id": "297",
 			"label": "Nondetection",
 			"levels3d": {
 				"enable": false,
@@ -61258,7 +61501,7 @@
 			}
 		},
 		{
-			"id": "297",
+			"id": "298",
 			"label": "Passwall",
 			"levels3d": {
 				"enable": false,
@@ -61456,7 +61699,7 @@
 			}
 		},
 		{
-			"id": "298",
+			"id": "299",
 			"label": "Phantasmal Killer",
 			"levels3d": {
 				"type": "explosion",
@@ -61650,7 +61893,7 @@
 			}
 		},
 		{
-			"id": "299",
+			"id": "300",
 			"label": "Phantom Steed",
 			"levels3d": {
 				"enable": false,
@@ -61847,7 +62090,7 @@
 			}
 		},
 		{
-			"id": "300",
+			"id": "301",
 			"label": "Planar Ally",
 			"levels3d": {
 				"type": "explosion",
@@ -62041,7 +62284,7 @@
 			}
 		},
 		{
-			"id": "301",
+			"id": "302",
 			"label": "Plane Shift",
 			"levels3d": {
 				"type": "explosion",
@@ -62235,7 +62478,7 @@
 			}
 		},
 		{
-			"id": "302",
+			"id": "303",
 			"label": "Plant Growth",
 			"levels3d": {
 				"enable": false,
@@ -62432,7 +62675,7 @@
 			}
 		},
 		{
-			"id": "303",
+			"id": "304",
 			"label": "Polymorph",
 			"levels3d": {
 				"type": "explosion",
@@ -62628,7 +62871,7 @@
 			}
 		},
 		{
-			"id": "304",
+			"id": "305",
 			"label": "Potion of",
 			"levels3d": {
 				"type": "explosion",
@@ -62822,7 +63065,7 @@
 			}
 		},
 		{
-			"id": "305",
+			"id": "306",
 			"label": "Power Word",
 			"levels3d": {
 				"enable": false,
@@ -63019,7 +63262,7 @@
 			}
 		},
 		{
-			"id": "306",
+			"id": "307",
 			"label": "Power Word Heal",
 			"levels3d": {
 				"enable": false,
@@ -63216,7 +63459,7 @@
 			}
 		},
 		{
-			"id": "307",
+			"id": "308",
 			"label": "Prayer of Healing",
 			"levels3d": {
 				"enable": false,
@@ -63413,7 +63656,7 @@
 			}
 		},
 		{
-			"id": "308",
+			"id": "309",
 			"label": "Prestidigitation",
 			"levels3d": {
 				"enable": false,
@@ -63611,7 +63854,7 @@
 			}
 		},
 		{
-			"id": "309",
+			"id": "310",
 			"label": "Primal Savagery",
 			"levels3d": {
 				"enable": false,
@@ -63808,7 +64051,7 @@
 			}
 		},
 		{
-			"id": "310",
+			"id": "311",
 			"label": "Project Image",
 			"levels3d": {
 				"type": "explosion",
@@ -64004,7 +64247,7 @@
 			}
 		},
 		{
-			"id": "311",
+			"id": "312",
 			"label": "Protection from Energy",
 			"levels3d": {
 				"enable": false,
@@ -64201,7 +64444,7 @@
 			}
 		},
 		{
-			"id": "312",
+			"id": "313",
 			"label": "Protection from Evil and Good",
 			"levels3d": {
 				"enable": false,
@@ -64398,7 +64641,7 @@
 			}
 		},
 		{
-			"id": "313",
+			"id": "314",
 			"label": "Protection from Poison",
 			"levels3d": {
 				"enable": false,
@@ -64595,7 +64838,7 @@
 			}
 		},
 		{
-			"id": "314",
+			"id": "315",
 			"label": "Rage",
 			"levels3d": {
 				"enable": false,
@@ -64792,7 +65035,7 @@
 			}
 		},
 		{
-			"id": "315",
+			"id": "316",
 			"label": "Raise Dead",
 			"levels3d": {
 				"enable": false,
@@ -64989,7 +65232,7 @@
 			}
 		},
 		{
-			"id": "316",
+			"id": "317",
 			"label": "Regenerate",
 			"levels3d": {
 				"enable": false,
@@ -65186,7 +65429,7 @@
 			}
 		},
 		{
-			"id": "317",
+			"id": "318",
 			"label": "Reincarnate",
 			"levels3d": {
 				"type": "explosion",
@@ -65380,7 +65623,7 @@
 			}
 		},
 		{
-			"id": "318",
+			"id": "319",
 			"label": "Remove Curse",
 			"levels3d": {
 				"enable": false,
@@ -65577,7 +65820,7 @@
 			}
 		},
 		{
-			"id": "319",
+			"id": "320",
 			"label": "Resilient Sphere",
 			"levels3d": {
 				"type": "explosion",
@@ -65771,7 +66014,7 @@
 			}
 		},
 		{
-			"id": "320",
+			"id": "321",
 			"label": "Resistance",
 			"levels3d": {
 				"type": "explosion",
@@ -65964,7 +66207,7 @@
 			}
 		},
 		{
-			"id": "321",
+			"id": "322",
 			"label": "Restoration",
 			"levels3d": {
 				"enable": false,
@@ -66161,7 +66404,7 @@
 			}
 		},
 		{
-			"id": "322",
+			"id": "323",
 			"label": "Resurrection",
 			"levels3d": {
 				"enable": false,
@@ -66358,7 +66601,7 @@
 			}
 		},
 		{
-			"id": "323",
+			"id": "324",
 			"label": "Revivify",
 			"levels3d": {
 				"enable": false,
@@ -66555,7 +66798,7 @@
 			}
 		},
 		{
-			"id": "324",
+			"id": "325",
 			"label": "Rope Trick",
 			"levels3d": {
 				"enable": false,
@@ -66752,7 +66995,7 @@
 			}
 		},
 		{
-			"id": "325",
+			"id": "326",
 			"label": "Sacred Flame",
 			"levels3d": {
 				"enable": false,
@@ -66979,7 +67222,7 @@
 			}
 		},
 		{
-			"id": "326",
+			"id": "327",
 			"label": "Sanctuary",
 			"levels3d": {
 				"enable": false,
@@ -67176,7 +67419,7 @@
 			}
 		},
 		{
-			"id": "327",
+			"id": "328",
 			"label": "Sapping Sting",
 			"levels3d": {
 				"enable": false,
@@ -67375,7 +67618,7 @@
 			}
 		},
 		{
-			"id": "328",
+			"id": "329",
 			"label": "Scrying",
 			"levels3d": {
 				"type": "explosion",
@@ -67573,7 +67816,7 @@
 			}
 		},
 		{
-			"id": "329",
+			"id": "330",
 			"label": "Second Wind",
 			"levels3d": {
 				"enable": false,
@@ -67770,7 +68013,7 @@
 			}
 		},
 		{
-			"id": "330",
+			"id": "331",
 			"label": "See Invisibility",
 			"levels3d": {
 				"enable": false,
@@ -67967,7 +68210,7 @@
 			}
 		},
 		{
-			"id": "331",
+			"id": "332",
 			"label": "Seeming",
 			"levels3d": {
 				"type": "explosion",
@@ -68161,7 +68404,7 @@
 			}
 		},
 		{
-			"id": "332",
+			"id": "333",
 			"label": "Sending",
 			"levels3d": {
 				"enable": false,
@@ -68358,7 +68601,7 @@
 			}
 		},
 		{
-			"id": "333",
+			"id": "334",
 			"label": "Shadow of Moil",
 			"levels3d": {
 				"enable": false,
@@ -68555,7 +68798,7 @@
 			}
 		},
 		{
-			"id": "334",
+			"id": "335",
 			"label": "Shape Water",
 			"levels3d": {
 				"enable": false,
@@ -68754,7 +68997,7 @@
 			}
 		},
 		{
-			"id": "335",
+			"id": "336",
 			"label": "Shield of Faith",
 			"levels3d": {
 				"type": "explosion",
@@ -68959,7 +69202,7 @@
 			}
 		},
 		{
-			"id": "336",
+			"id": "337",
 			"label": "Shocking Grasp",
 			"levels3d": {
 				"enable": false,
@@ -69156,7 +69399,7 @@
 			}
 		},
 		{
-			"id": "337",
+			"id": "338",
 			"label": "Smite",
 			"levels3d": {
 				"enable": false,
@@ -69353,7 +69596,7 @@
 			}
 		},
 		{
-			"id": "338",
+			"id": "339",
 			"label": "Snare",
 			"levels3d": {
 				"enable": false,
@@ -69550,7 +69793,7 @@
 			}
 		},
 		{
-			"id": "339",
+			"id": "340",
 			"label": "Sneak Attack",
 			"levels3d": {
 				"type": "explosion",
@@ -69743,7 +69986,7 @@
 			}
 		},
 		{
-			"id": "340",
+			"id": "341",
 			"label": "Song of Rest",
 			"levels3d": {
 				"type": "explosion",
@@ -69955,7 +70198,7 @@
 			}
 		},
 		{
-			"id": "341",
+			"id": "342",
 			"label": "Spare the Dying",
 			"levels3d": {
 				"enable": false,
@@ -70155,7 +70398,7 @@
 			}
 		},
 		{
-			"id": "342",
+			"id": "343",
 			"label": "Speak with Animals",
 			"levels3d": {
 				"enable": false,
@@ -70352,7 +70595,7 @@
 			}
 		},
 		{
-			"id": "343",
+			"id": "344",
 			"label": "Speak with Dead",
 			"levels3d": {
 				"enable": false,
@@ -70549,7 +70792,7 @@
 			}
 		},
 		{
-			"id": "344",
+			"id": "345",
 			"label": "Speak with Plants",
 			"levels3d": {
 				"enable": false,
@@ -70746,7 +70989,7 @@
 			}
 		},
 		{
-			"id": "345",
+			"id": "346",
 			"label": "Spectral Fangs",
 			"levels3d": {
 				"type": "explosion",
@@ -70942,7 +71185,7 @@
 			}
 		},
 		{
-			"id": "346",
+			"id": "347",
 			"label": "Spider Climb",
 			"levels3d": {
 				"enable": false,
@@ -71147,7 +71390,7 @@
 			}
 		},
 		{
-			"id": "347",
+			"id": "348",
 			"label": "Spirit Shroud",
 			"levels3d": {
 				"enable": false,
@@ -71344,7 +71587,7 @@
 			}
 		},
 		{
-			"id": "348",
+			"id": "349",
 			"label": "Spiritual Weapon",
 			"levels3d": {
 				"enable": false,
@@ -71541,7 +71784,7 @@
 			}
 		},
 		{
-			"id": "349",
+			"id": "350",
 			"label": "Spore",
 			"levels3d": {
 				"type": "explosion",
@@ -71735,7 +71978,7 @@
 			}
 		},
 		{
-			"id": "350",
+			"id": "351",
 			"label": "Stillness of Mind",
 			"levels3d": {
 				"enable": false,
@@ -71962,7 +72205,7 @@
 			}
 		},
 		{
-			"id": "351",
+			"id": "352",
 			"label": "Stone Shape",
 			"levels3d": {
 				"type": "explosion",
@@ -72158,7 +72401,7 @@
 			}
 		},
 		{
-			"id": "352",
+			"id": "353",
 			"label": "Stoneskin",
 			"levels3d": {
 				"enable": false,
@@ -72355,7 +72598,7 @@
 			}
 		},
 		{
-			"id": "353",
+			"id": "354",
 			"label": "Suggestion",
 			"levels3d": {
 				"enable": false,
@@ -72557,7 +72800,7 @@
 			}
 		},
 		{
-			"id": "354",
+			"id": "355",
 			"label": "Summon",
 			"levels3d": {
 				"enable": false,
@@ -72754,7 +72997,7 @@
 			}
 		},
 		{
-			"id": "355",
+			"id": "356",
 			"label": "Swallow",
 			"levels3d": {
 				"type": "explosion",
@@ -72950,7 +73193,7 @@
 			}
 		},
 		{
-			"id": "356",
+			"id": "357",
 			"label": "Swift Quiver",
 			"levels3d": {
 				"type": "explosion",
@@ -73144,7 +73387,7 @@
 			}
 		},
 		{
-			"id": "357",
+			"id": "358",
 			"label": "Symbol",
 			"levels3d": {
 				"type": "explosion",
@@ -73340,7 +73583,7 @@
 			}
 		},
 		{
-			"id": "358",
+			"id": "359",
 			"label": "Talon",
 			"levels3d": {
 				"enable": false,
@@ -73537,7 +73780,7 @@
 			}
 		},
 		{
-			"id": "359",
+			"id": "360",
 			"label": "Tasha's Otherworldly Guise",
 			"levels3d": {
 				"enable": false,
@@ -73734,7 +73977,7 @@
 			}
 		},
 		{
-			"id": "360",
+			"id": "361",
 			"label": "Telekinesis",
 			"levels3d": {
 				"type": "explosion",
@@ -73928,7 +74171,7 @@
 			}
 		},
 		{
-			"id": "361",
+			"id": "362",
 			"label": "Tentacle",
 			"levels3d": {
 				"enable": false,
@@ -74125,7 +74368,7 @@
 			}
 		},
 		{
-			"id": "362",
+			"id": "363",
 			"label": "Thaumaturgy",
 			"levels3d": {
 				"enable": false,
@@ -74323,7 +74566,7 @@
 			}
 		},
 		{
-			"id": "363",
+			"id": "364",
 			"label": "Thunderclap",
 			"levels3d": {
 				"enable": false,
@@ -74521,7 +74764,7 @@
 			}
 		},
 		{
-			"id": "364",
+			"id": "365",
 			"label": "Time Stop",
 			"levels3d": {
 				"enable": false,
@@ -74718,7 +74961,7 @@
 			}
 		},
 		{
-			"id": "365",
+			"id": "366",
 			"label": "Toll the Dead",
 			"levels3d": {
 				"enable": false,
@@ -74944,7 +75187,7 @@
 			}
 		},
 		{
-			"id": "366",
+			"id": "367",
 			"label": "Tongue",
 			"levels3d": {
 				"type": "explosion",
@@ -75140,7 +75383,7 @@
 			}
 		},
 		{
-			"id": "367",
+			"id": "368",
 			"label": "Tongues",
 			"levels3d": {
 				"enable": false,
@@ -75338,7 +75581,7 @@
 			}
 		},
 		{
-			"id": "368",
+			"id": "369",
 			"label": "Touch",
 			"levels3d": {
 				"type": "explosion",
@@ -75532,7 +75775,7 @@
 			}
 		},
 		{
-			"id": "369",
+			"id": "370",
 			"label": "Tree Stride",
 			"levels3d": {
 				"type": "explosion",
@@ -75726,7 +75969,7 @@
 			}
 		},
 		{
-			"id": "370",
+			"id": "371",
 			"label": "True Seeing",
 			"levels3d": {
 				"enable": false,
@@ -75926,7 +76169,7 @@
 			}
 		},
 		{
-			"id": "371",
+			"id": "372",
 			"label": "True Strike",
 			"levels3d": {
 				"enable": false,
@@ -76125,7 +76368,7 @@
 			}
 		},
 		{
-			"id": "372",
+			"id": "373",
 			"label": "Unseen Servant",
 			"levels3d": {
 				"enable": false,
@@ -76322,7 +76565,7 @@
 			}
 		},
 		{
-			"id": "373",
+			"id": "374",
 			"label": "Unsettling Words",
 			"levels3d": {
 				"type": "explosion",
@@ -76535,7 +76778,7 @@
 			}
 		},
 		{
-			"id": "374",
+			"id": "375",
 			"label": "Vampiric Touch",
 			"levels3d": {
 				"enable": false,
@@ -76732,7 +76975,7 @@
 			}
 		},
 		{
-			"id": "375",
+			"id": "376",
 			"label": "Vicious Mockery",
 			"levels3d": {
 				"enable": false,
@@ -76936,7 +77179,7 @@
 			}
 		},
 		{
-			"id": "376",
+			"id": "377",
 			"label": "Vigilant Blessing",
 			"levels3d": {
 				"type": "explosion",
@@ -77130,7 +77373,7 @@
 			}
 		},
 		{
-			"id": "377",
+			"id": "378",
 			"label": "Vortex Warp",
 			"levels3d": {
 				"enable": false,
@@ -77327,7 +77570,7 @@
 			}
 		},
 		{
-			"id": "378",
+			"id": "379",
 			"label": "Wall of Light",
 			"levels3d": {
 				"enable": false,
@@ -77524,7 +77767,7 @@
 			}
 		},
 		{
-			"id": "379",
+			"id": "380",
 			"label": "Warding Bond",
 			"levels3d": {
 				"enable": false,
@@ -77721,7 +77964,7 @@
 			}
 		},
 		{
-			"id": "380",
+			"id": "381",
 			"label": "Water Breathing",
 			"levels3d": {
 				"enable": false,
@@ -77918,7 +78161,7 @@
 			}
 		},
 		{
-			"id": "381",
+			"id": "382",
 			"label": "Water Walk",
 			"levels3d": {
 				"enable": false,
@@ -78115,7 +78358,7 @@
 			}
 		},
 		{
-			"id": "382",
+			"id": "383",
 			"label": "Wild Shape",
 			"levels3d": {
 				"enable": false,
@@ -78312,7 +78555,7 @@
 			}
 		},
 		{
-			"id": "383",
+			"id": "384",
 			"label": "Wind Walk",
 			"levels3d": {
 				"type": "explosion",
@@ -78508,7 +78751,7 @@
 			}
 		},
 		{
-			"id": "384",
+			"id": "385",
 			"label": "Wish",
 			"levels3d": {
 				"type": "explosion",
@@ -78702,7 +78945,7 @@
 			}
 		},
 		{
-			"id": "385",
+			"id": "386",
 			"label": "Withering Touch",
 			"levels3d": {
 				"type": "explosion",
@@ -78899,7 +79142,7 @@
 			}
 		},
 		{
-			"id": "386",
+			"id": "387",
 			"label": "Word of Radiance",
 			"levels3d": {
 				"enable": false,
@@ -79097,7 +79340,7 @@
 			}
 		},
 		{
-			"id": "387",
+			"id": "388",
 			"label": "Zephyr Strike",
 			"levels3d": {
 				"enable": false,
@@ -79295,11 +79538,420 @@
 				"moduleVersion": "1.2.0",
 				"version": 5
 			}
+		},
+		{
+			"id": "389",
+			"label": "Deflect Missiles",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "impact",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_generic.piercing.two_handed"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Ranged_Projectile/ranged-projectile-launch.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.6,0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Deflect Missiles",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 1
+			}
+		},
+		{
+			"id": "390",
+			"label": "Quickened Healing",
+			"levels3d": {
+				"enable": false,
+				"type": "",
+				"data": {},
+				"secondary": {
+					"enable": false,
+					"data": {}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-1.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "generichealing",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Quickened Healing",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 1
+			}
 		}
 	],
 	"templatefx": [
 		{
-			"id": "388",
+			"id": "391",
 			"label": "Acid Breath",
 			"macro": {
 				"enable": false,
@@ -79478,7 +80130,7 @@
 			}
 		},
 		{
-			"id": "389",
+			"id": "392",
 			"label": "Aganazzar's Scorcher",
 			"macro": {
 				"enable": false,
@@ -79654,7 +80306,7 @@
 			}
 		},
 		{
-			"id": "390",
+			"id": "393",
 			"label": "Black Tentacles",
 			"macro": {
 				"enable": false,
@@ -79830,7 +80482,7 @@
 			}
 		},
 		{
-			"id": "391",
+			"id": "394",
 			"label": "Blade Barrier",
 			"macro": {
 				"enable": false,
@@ -80021,7 +80673,7 @@
 			}
 		},
 		{
-			"id": "392",
+			"id": "395",
 			"label": "Burning Hands",
 			"macro": {
 				"enable": false,
@@ -80197,7 +80849,7 @@
 			}
 		},
 		{
-			"id": "393",
+			"id": "396",
 			"label": "Call Lightning",
 			"macro": {
 				"enable": false,
@@ -80373,7 +81025,7 @@
 			}
 		},
 		{
-			"id": "394",
+			"id": "397",
 			"label": "Calm Emotions",
 			"macro": {
 				"enable": false,
@@ -80549,7 +81201,7 @@
 			}
 		},
 		{
-			"id": "395",
+			"id": "398",
 			"label": "Caustic Brew",
 			"macro": {
 				"enable": false,
@@ -80725,7 +81377,7 @@
 			}
 		},
 		{
-			"id": "396",
+			"id": "399",
 			"label": "Circle of Death",
 			"macro": {
 				"enable": false,
@@ -80900,7 +81552,7 @@
 			}
 		},
 		{
-			"id": "397",
+			"id": "400",
 			"label": "Cloud of Daggers",
 			"macro": {
 				"enable": false,
@@ -81076,7 +81728,7 @@
 			}
 		},
 		{
-			"id": "398",
+			"id": "401",
 			"label": "Cloudkill",
 			"macro": {
 				"enable": false,
@@ -81250,7 +81902,7 @@
 			}
 		},
 		{
-			"id": "399",
+			"id": "402",
 			"label": "Cold Breath",
 			"macro": {
 				"enable": false,
@@ -81429,7 +82081,7 @@
 			}
 		},
 		{
-			"id": "400",
+			"id": "403",
 			"label": "Color Spray",
 			"macro": {
 				"enable": false,
@@ -81605,7 +82257,7 @@
 			}
 		},
 		{
-			"id": "401",
+			"id": "404",
 			"label": "Cone of Cold",
 			"macro": {
 				"enable": false,
@@ -81781,7 +82433,7 @@
 			}
 		},
 		{
-			"id": "402",
+			"id": "405",
 			"label": "Confusion",
 			"macro": {
 				"enable": false,
@@ -81955,7 +82607,7 @@
 			}
 		},
 		{
-			"id": "403",
+			"id": "406",
 			"label": "Control",
 			"macro": {
 				"enable": false,
@@ -82131,7 +82783,7 @@
 			}
 		},
 		{
-			"id": "404",
+			"id": "407",
 			"label": "Create or Destroy Water",
 			"macro": {
 				"enable": false,
@@ -82307,7 +82959,7 @@
 			}
 		},
 		{
-			"id": "405",
+			"id": "408",
 			"label": "Creation",
 			"macro": {
 				"enable": false,
@@ -82482,7 +83134,7 @@
 			}
 		},
 		{
-			"id": "406",
+			"id": "409",
 			"label": "Crusader's Mantle",
 			"macro": {
 				"enable": false,
@@ -82658,7 +83310,7 @@
 			}
 		},
 		{
-			"id": "407",
+			"id": "410",
 			"label": "Darkness",
 			"macro": {
 				"enable": false,
@@ -82834,7 +83486,7 @@
 			}
 		},
 		{
-			"id": "408",
+			"id": "411",
 			"label": "Daylight",
 			"macro": {
 				"enable": false,
@@ -83012,7 +83664,7 @@
 			}
 		},
 		{
-			"id": "409",
+			"id": "412",
 			"label": "Destructive Wave",
 			"macro": {
 				"enable": false,
@@ -83188,7 +83840,7 @@
 			}
 		},
 		{
-			"id": "410",
+			"id": "413",
 			"label": "Earthquake",
 			"macro": {
 				"enable": false,
@@ -83365,7 +84017,7 @@
 			}
 		},
 		{
-			"id": "411",
+			"id": "414",
 			"label": "Entangle",
 			"macro": {
 				"enable": false,
@@ -83541,7 +84193,7 @@
 			}
 		},
 		{
-			"id": "412",
+			"id": "415",
 			"label": "Fear",
 			"macro": {
 				"enable": false,
@@ -83717,7 +84369,7 @@
 			}
 		},
 		{
-			"id": "413",
+			"id": "416",
 			"label": "Fire Breath",
 			"macro": {
 				"enable": false,
@@ -83896,7 +84548,7 @@
 			}
 		},
 		{
-			"id": "414",
+			"id": "417",
 			"label": "Fire Storm",
 			"macro": {
 				"enable": false,
@@ -84070,7 +84722,7 @@
 			}
 		},
 		{
-			"id": "415",
+			"id": "418",
 			"label": "Flame Strike",
 			"macro": {
 				"enable": false,
@@ -84246,7 +84898,7 @@
 			}
 		},
 		{
-			"id": "416",
+			"id": "419",
 			"label": "Flaming Sphere",
 			"macro": {
 				"enable": false,
@@ -84422,7 +85074,7 @@
 			}
 		},
 		{
-			"id": "417",
+			"id": "420",
 			"label": "Fog Cloud",
 			"macro": {
 				"enable": false,
@@ -84598,7 +85250,7 @@
 			}
 		},
 		{
-			"id": "418",
+			"id": "421",
 			"label": "Globe of Invulnerability",
 			"macro": {
 				"enable": false,
@@ -84775,7 +85427,7 @@
 			}
 		},
 		{
-			"id": "419",
+			"id": "422",
 			"label": "Grease",
 			"macro": {
 				"enable": false,
@@ -84952,7 +85604,7 @@
 			}
 		},
 		{
-			"id": "420",
+			"id": "423",
 			"label": "Gust of Wind",
 			"macro": {
 				"enable": false,
@@ -85128,7 +85780,7 @@
 			}
 		},
 		{
-			"id": "421",
+			"id": "424",
 			"label": "Hallow",
 			"macro": {
 				"enable": false,
@@ -85303,7 +85955,7 @@
 			}
 		},
 		{
-			"id": "422",
+			"id": "425",
 			"label": "Hallucinatory Terrain",
 			"macro": {
 				"enable": false,
@@ -85478,7 +86130,7 @@
 			}
 		},
 		{
-			"id": "423",
+			"id": "426",
 			"label": "Healing Spirit",
 			"macro": {
 				"enable": false,
@@ -85655,7 +86307,7 @@
 			}
 		},
 		{
-			"id": "424",
+			"id": "427",
 			"label": "Hunger of Hadar",
 			"macro": {
 				"enable": false,
@@ -85831,7 +86483,7 @@
 			}
 		},
 		{
-			"id": "425",
+			"id": "428",
 			"label": "Hypnotic Pattern",
 			"macro": {
 				"enable": false,
@@ -86009,7 +86661,7 @@
 			}
 		},
 		{
-			"id": "426",
+			"id": "429",
 			"label": "Ice Storm",
 			"macro": {
 				"enable": false,
@@ -86185,7 +86837,7 @@
 			}
 		},
 		{
-			"id": "427",
+			"id": "430",
 			"label": "Image",
 			"macro": {
 				"enable": false,
@@ -86361,7 +87013,7 @@
 			}
 		},
 		{
-			"id": "428",
+			"id": "431",
 			"label": "Incendiary Cloud",
 			"macro": {
 				"enable": false,
@@ -86536,7 +87188,7 @@
 			}
 		},
 		{
-			"id": "429",
+			"id": "432",
 			"label": "Insect Plague",
 			"macro": {
 				"enable": false,
@@ -86711,7 +87363,7 @@
 			}
 		},
 		{
-			"id": "430",
+			"id": "433",
 			"label": "Lightning Bolt",
 			"macro": {
 				"enable": false,
@@ -86888,7 +87540,7 @@
 			}
 		},
 		{
-			"id": "431",
+			"id": "434",
 			"label": "Lightning Breath",
 			"macro": {
 				"enable": false,
@@ -87067,7 +87719,7 @@
 			}
 		},
 		{
-			"id": "432",
+			"id": "435",
 			"label": "Magic Circle",
 			"macro": {
 				"enable": false,
@@ -87243,7 +87895,7 @@
 			}
 		},
 		{
-			"id": "433",
+			"id": "436",
 			"label": "Mind Blast",
 			"macro": {
 				"enable": false,
@@ -87418,7 +88070,7 @@
 			}
 		},
 		{
-			"id": "434",
+			"id": "437",
 			"label": "Minor Illusion",
 			"macro": {
 				"enable": false,
@@ -87609,7 +88261,7 @@
 			}
 		},
 		{
-			"id": "435",
+			"id": "438",
 			"label": "Mirage Arcane",
 			"macro": {
 				"enable": false,
@@ -87783,7 +88435,7 @@
 			}
 		},
 		{
-			"id": "436",
+			"id": "439",
 			"label": "Moonbeam",
 			"macro": {
 				"enable": false,
@@ -87959,7 +88611,7 @@
 			}
 		},
 		{
-			"id": "437",
+			"id": "440",
 			"label": "Move Earth",
 			"macro": {
 				"enable": false,
@@ -88134,7 +88786,7 @@
 			}
 		},
 		{
-			"id": "438",
+			"id": "441",
 			"label": "Paralyzing Breath",
 			"macro": {
 				"enable": false,
@@ -88312,7 +88964,7 @@
 			}
 		},
 		{
-			"id": "439",
+			"id": "442",
 			"label": "Phantasmal Force",
 			"macro": {
 				"enable": false,
@@ -88488,7 +89140,7 @@
 			}
 		},
 		{
-			"id": "440",
+			"id": "443",
 			"label": "Poison Breath",
 			"macro": {
 				"enable": false,
@@ -88666,7 +89318,7 @@
 			}
 		},
 		{
-			"id": "441",
+			"id": "444",
 			"label": "Prismatic Spray",
 			"macro": {
 				"enable": false,
@@ -88840,7 +89492,7 @@
 			}
 		},
 		{
-			"id": "442",
+			"id": "445",
 			"label": "Prismatic Wall",
 			"macro": {
 				"enable": false,
@@ -89033,7 +89685,7 @@
 			}
 		},
 		{
-			"id": "443",
+			"id": "446",
 			"label": "Programmed Illusion",
 			"macro": {
 				"enable": false,
@@ -89208,7 +89860,7 @@
 			}
 		},
 		{
-			"id": "444",
+			"id": "447",
 			"label": "Purify Food and Drink",
 			"macro": {
 				"enable": false,
@@ -89384,7 +90036,7 @@
 			}
 		},
 		{
-			"id": "445",
+			"id": "448",
 			"label": "Repulsion Breath",
 			"macro": {
 				"enable": false,
@@ -89562,7 +90214,7 @@
 			}
 		},
 		{
-			"id": "446",
+			"id": "449",
 			"label": "Rime's Binding Ice",
 			"macro": {
 				"enable": false,
@@ -89738,7 +90390,7 @@
 			}
 		},
 		{
-			"id": "447",
+			"id": "450",
 			"label": "Shatter",
 			"macro": {
 				"enable": false,
@@ -89914,7 +90566,7 @@
 			}
 		},
 		{
-			"id": "448",
+			"id": "451",
 			"label": "Sickening Radiance",
 			"macro": {
 				"enable": false,
@@ -90090,7 +90742,7 @@
 			}
 		},
 		{
-			"id": "449",
+			"id": "452",
 			"label": "Silence",
 			"macro": {
 				"enable": false,
@@ -90267,7 +90919,7 @@
 			}
 		},
 		{
-			"id": "450",
+			"id": "453",
 			"label": "Sleet Storm",
 			"macro": {
 				"enable": false,
@@ -90443,7 +91095,7 @@
 			}
 		},
 		{
-			"id": "451",
+			"id": "454",
 			"label": "Slow",
 			"macro": {
 				"enable": false,
@@ -90618,7 +91270,7 @@
 			}
 		},
 		{
-			"id": "452",
+			"id": "455",
 			"label": "Slowing Breath",
 			"macro": {
 				"enable": false,
@@ -90796,7 +91448,7 @@
 			}
 		},
 		{
-			"id": "453",
+			"id": "456",
 			"label": "Spike Growth",
 			"macro": {
 				"enable": false,
@@ -90972,7 +91624,7 @@
 			}
 		},
 		{
-			"id": "454",
+			"id": "457",
 			"label": "Stinking Cloud",
 			"macro": {
 				"enable": false,
@@ -91148,7 +91800,7 @@
 			}
 		},
 		{
-			"id": "455",
+			"id": "458",
 			"label": "Storm Sphere",
 			"macro": {
 				"enable": false,
@@ -91324,7 +91976,7 @@
 			}
 		},
 		{
-			"id": "456",
+			"id": "459",
 			"label": "Sunbeam",
 			"macro": {
 				"enable": false,
@@ -91499,7 +92151,7 @@
 			}
 		},
 		{
-			"id": "457",
+			"id": "460",
 			"label": "Sunburst",
 			"macro": {
 				"enable": false,
@@ -91676,7 +92328,7 @@
 			}
 		},
 		{
-			"id": "458",
+			"id": "461",
 			"label": "Synaptic Static",
 			"macro": {
 				"enable": false,
@@ -91852,7 +92504,7 @@
 			}
 		},
 		{
-			"id": "459",
+			"id": "462",
 			"label": "Teleportation Circle",
 			"macro": {
 				"enable": false,
@@ -92027,7 +92679,7 @@
 			}
 		},
 		{
-			"id": "460",
+			"id": "463",
 			"label": "Tiny Hut",
 			"macro": {
 				"enable": false,
@@ -92205,7 +92857,7 @@
 			}
 		},
 		{
-			"id": "461",
+			"id": "464",
 			"label": "Wall of Fire",
 			"macro": {
 				"enable": false,
@@ -92382,7 +93034,7 @@
 			}
 		},
 		{
-			"id": "462",
+			"id": "465",
 			"label": "Wall of Force",
 			"macro": {
 				"enable": false,
@@ -92572,7 +93224,7 @@
 			}
 		},
 		{
-			"id": "463",
+			"id": "466",
 			"label": "Wall of Ice",
 			"macro": {
 				"enable": false,
@@ -92762,7 +93414,7 @@
 			}
 		},
 		{
-			"id": "464",
+			"id": "467",
 			"label": "Wall of Stone",
 			"macro": {
 				"enable": false,
@@ -92952,7 +93604,7 @@
 			}
 		},
 		{
-			"id": "465",
+			"id": "468",
 			"label": "Wall of Thorns",
 			"macro": {
 				"enable": false,
@@ -93142,7 +93794,7 @@
 			}
 		},
 		{
-			"id": "466",
+			"id": "469",
 			"label": "Weakening Breath",
 			"macro": {
 				"enable": false,
@@ -93320,7 +93972,7 @@
 			}
 		},
 		{
-			"id": "467",
+			"id": "470",
 			"label": "Web",
 			"macro": {
 				"enable": false,
@@ -93496,7 +94148,7 @@
 			}
 		},
 		{
-			"id": "468",
+			"id": "471",
 			"label": "Wind Wall",
 			"macro": {
 				"enable": false,
@@ -93673,7 +94325,7 @@
 			}
 		},
 		{
-			"id": "469",
+			"id": "472",
 			"label": "Wither and Bloom",
 			"macro": {
 				"enable": false,
@@ -93849,7 +94501,7 @@
 			}
 		},
 		{
-			"id": "470",
+			"id": "473",
 			"label": "Zone of Truth",
 			"macro": {
 				"enable": false,
@@ -94027,7 +94679,7 @@
 	],
 	"preset": [
 		{
-			"id": "471",
+			"id": "474",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -94213,12 +94865,21 @@
 				"label": "Conjure Barrage",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "472",
+			"id": "475",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -94402,12 +95063,21 @@
 				"label": "Delayed Blast Fireball",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "473",
+			"id": "476",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -94506,12 +95176,21 @@
 				"label": "Dimension Door",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "474",
+			"id": "477",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -94606,12 +95285,21 @@
 				"label": "Far Step",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "475",
+			"id": "478",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -94796,12 +95484,21 @@
 				"label": "Fireball",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "476",
+			"id": "479",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -94985,12 +95682,21 @@
 				"label": "Freezing Sphere",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "477",
+			"id": "480",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -95165,15 +95871,24 @@
 				"label": "Meteor Swarm",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "478",
+			"id": "481",
 			"data": {
 				"options": {
-					"alpha": 0,
+					"alpha": 0.01,
 					"delayFade": 750,
 					"delayMove": 1000,
 					"delayReturn": 250,
@@ -95266,12 +95981,21 @@
 				"label": "Misty Step",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "479",
+			"id": "482",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -95454,15 +96178,24 @@
 				"label": "Sleep",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "480",
+			"id": "483",
 			"data": {
 				"options": {
-					"alpha": 0.02,
+					"alpha": 0.01,
 					"delayFade": 750,
 					"delayMove": 1000,
 					"delayReturn": 250,
@@ -95554,15 +96287,24 @@
 				"label": "Starlight Step",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "481",
+			"id": "484",
 			"data": {
 				"options": {
-					"alpha": 0,
+					"alpha": 0.01,
 					"delayFade": 750,
 					"delayMove": 1000,
 					"delayReturn": 250,
@@ -95654,15 +96396,24 @@
 				"label": "Teleport",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "482",
+			"id": "485",
 			"data": {
 				"options": {
-					"alpha": 0,
+					"alpha": 0.01,
 					"delayFade": 750,
 					"delayMove": 1000,
 					"delayReturn": 250,
@@ -95754,12 +96505,21 @@
 				"label": "Thunder Step",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "483",
+			"id": "486",
 			"macro": {
 				"enable": false,
 				"playWhen": "0"
@@ -95804,12 +96564,21 @@
 				"label": "Thunderwave",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "484",
+			"id": "487",
 			"data": {
 				"video": {
 					"dbSection": "range",
@@ -95855,14 +96624,23 @@
 				"label": "Witch Bolt",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		}
 	],
 	"aura": [
 		{
-			"id": "485",
+			"id": "488",
 			"label": "Antilife Shell",
 			"macro": {
 				"enable": false,
@@ -96042,12 +96820,21 @@
 				"label": "Antilife Shell",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "486",
+			"id": "489",
 			"label": "Antimagic Field",
 			"macro": {
 				"enable": false,
@@ -96227,12 +97014,21 @@
 				"label": "Antimagic Field",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "487",
+			"id": "490",
 			"label": "Aura of",
 			"macro": {
 				"enable": false,
@@ -96412,10 +97208,19 @@
 				"name": "5e Animations",
 				"moduleVersion": "1.2.0",
 				"version": 5
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "488",
+			"id": "491",
 			"label": "Aura of Annihilation",
 			"macro": {
 				"enable": false,
@@ -96593,12 +97398,21 @@
 				"label": "Aura of Annihilation",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "489",
+			"id": "492",
 			"label": "Aura of Vitality",
 			"macro": {
 				"enable": false,
@@ -96773,7 +97587,7 @@
 				}
 			},
 			"advanced": {
-				"exactMatch": false,
+				"exactMatch": true,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -96785,12 +97599,12 @@
 				"label": "Aura of Vitality",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
 			}
 		},
 		{
-			"id": "490",
+			"id": "493",
 			"label": "Circle of Power",
 			"macro": {
 				"enable": false,
@@ -96968,12 +97782,21 @@
 				"label": "Circle of Power",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "491",
+			"id": "494",
 			"label": "Detect Evil and Good",
 			"macro": {
 				"enable": false,
@@ -97153,12 +97976,21 @@
 				"label": "Detect Evil and Good",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "492",
+			"id": "495",
 			"label": "Detect Magic",
 			"macro": {
 				"enable": false,
@@ -97338,12 +98170,21 @@
 				"label": "Detect Magic",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "493",
+			"id": "496",
 			"label": "Detect Poison and Disease",
 			"macro": {
 				"enable": false,
@@ -97523,12 +98364,21 @@
 				"label": "Detect Poison and Disease",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "494",
+			"id": "497",
 			"label": "Holy Aura",
 			"macro": {
 				"enable": false,
@@ -97708,12 +98558,21 @@
 				"label": "Holy Aura",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "495",
+			"id": "498",
 			"label": "Pass without Trace",
 			"macro": {
 				"enable": false,
@@ -97893,12 +98752,21 @@
 				"label": "Pass without Trace",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "496",
+			"id": "499",
 			"label": "Radiant Consumption",
 			"macro": {
 				"enable": false,
@@ -98088,12 +98956,21 @@
 				"label": "Radiant Consumption",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "497",
+			"id": "500",
 			"label": "Spirit Guardians",
 			"macro": {
 				"enable": false,
@@ -98273,14 +99150,23 @@
 				"label": "Spirit Guardians",
 				"menu": "aura",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		}
 	],
 	"aefx": [
 		{
-			"id": "498",
+			"id": "501",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
 			"secondary": {
@@ -98402,13 +99288,1040 @@
 				"label": "Abjuration Ward",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "499",
-			"label": "Bane",
+			"id": "502",
+			"label": "Incapacitated",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "conditions",
+					"animation": "crackedshield",
+					"variant": "01",
+					"color": "darkred",
+					"enableCustom": true,
+					"customPath": "jb2a.fireflies.many.01.blue"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": true,
+					"unbindVisibility": true,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Incapacitated",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "503",
+			"label": "Chill Shield",
+			"menu": "aefx",
+			"primary": {
+				"options": {
+					"isWait": true,
+					"delay": -1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 0,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": true,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"playOn": "source",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "ice",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"delay": -500,
+					"elevation": 1000,
+					"fadeIn": 500,
+					"fadeOut": 0,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "intro",
+					"variant": "02",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"secondary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"opacity": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "outro_explode",
+					"variant": "02",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"enable": false
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"soundOnly": {
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"activeEffectType": "ontoken",
+			"metaData": {
+				"label": "Chill Shield",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "504",
+			"label": "Unconscious",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "conditions",
+					"animation": "skull",
+					"variant": "02",
+					"color": "purple",
+					"enableCustom": true,
+					"customPath": "jb2a.glint.yellow.many.3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": true,
+					"unbindVisibility": true,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Unconscious",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "505",
+			"label": "Fire Shield",
+			"menu": "aefx",
+			"primary": {
+				"options": {
+					"isWait": true,
+					"delay": -1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 0,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": true,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"playOn": "source",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "loop",
+					"variant": "02",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"source": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"delay": -500,
+					"elevation": 1000,
+					"fadeIn": 500,
+					"fadeOut": 0,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "intro",
+					"variant": "02",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"secondary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"opacity": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "outro_explode",
+					"variant": "02",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"enable": true
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"soundOnly": {
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"activeEffectType": "ontoken",
+			"metaData": {
+				"label": "Fire Shield",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "506",
+			"label": "Frightened",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "conditions",
+					"animation": "horror",
+					"variant": "02",
+					"color": "random",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 0.75,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": true,
+					"unbindVisibility": true,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Frightened",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "507",
+			"label": "Restrained",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "chains",
+					"animation": "standard",
+					"variant": "complete",
+					"color": "random",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.5,
+					"persistent": true,
+					"playbackRate": 0.75,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"unbindAlpha": true,
+					"unbindVisibility": true,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Restrained",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "508",
+			"label": "Warm Shield",
+			"menu": "aefx",
+			"primary": {
+				"options": {
+					"isWait": true,
+					"delay": -1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 0,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": true,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"playOn": "source",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "fire",
+					"variant": "01",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"delay": -500,
+					"elevation": 1000,
+					"fadeIn": 500,
+					"fadeOut": 0,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "intro",
+					"variant": "02",
+					"color": "red",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"secondary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"opacity": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "outro_explode",
+					"variant": "02",
+					"color": "red",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"enable": false
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"soundOnly": {
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"activeEffectType": "ontoken",
+			"metaData": {
+				"label": "Warm Shield",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "509",
+			"label": "Mage Armor",
 			"menu": "aefx",
 			"secondary": {
 				"enable": false,
@@ -98442,14 +100355,14 @@
 					"breathMin": 0.95,
 					"breathDuration": 1000,
 					"delay": 0,
-					"elevation": 0,
+					"elevation": 1000,
 					"fadeIn": 250,
 					"fadeOut": 500,
 					"isRadius": true,
 					"isWait": true,
-					"opacity": 0.75,
+					"opacity": 0.5,
 					"playOn": "source",
-					"size": 1,
+					"size": 0.61,
 					"tint": false,
 					"tintColor": "#FFFFFF",
 					"tintSaturate": 0,
@@ -98460,20 +100373,20 @@
 				"sound": {
 					"delay": 0,
 					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-8.mp3",
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-short-4.mp3",
 					"startTime": 0,
 					"volume": 0.75,
 					"repeat": 1,
 					"repeatDelay": 250
 				},
 				"video": {
-					"animation": "bless",
-					"color": "purple",
+					"animation": "energyfield",
+					"color": "blue",
 					"customPath": "",
 					"dbSection": "static",
 					"enableCustom": false,
-					"menuType": "spell",
-					"variant": "loop"
+					"menuType": "shieldfx",
+					"variant": "01"
 				}
 			},
 			"macro": {
@@ -98528,15 +100441,172 @@
 			},
 			"activeEffectType": "aura",
 			"metaData": {
-				"label": "Bane",
+				"label": "Mage Armor",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "500",
+			"id": "510",
+			"label": "Paralyzed",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "conditions",
+					"animation": "stun",
+					"variant": "02",
+					"color": "random",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": true,
+					"unbindVisibility": true,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Paralyzed",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "511",
 			"label": "Barkskin",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -98679,7 +100749,7 @@
 				}
 			},
 			"advanced": {
-				"exactMatch": false,
+				"exactMatch": true,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -98691,423 +100761,12 @@
 				"label": "Barkskin",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
 			}
 		},
 		{
-			"id": "501",
-			"label": "Bless",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "bless",
-					"variant": "loop",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"alpha": false,
-					"alphaMax": 0.5,
-					"alphaMin": -0.5,
-					"alphaDuration": 1000,
-					"breath": false,
-					"breathMax": 1.05,
-					"breathMin": 0.95,
-					"breathDuration": 1000,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"playOn": "source",
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"tintSaturate": 0,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-continuous-1.mp3"
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"delay": -500,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "bless",
-					"variant": "intro",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"activeEffectType": "aura",
-			"metaData": {
-				"label": "Bless",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "502",
-			"label": "Charmed",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "conditions",
-					"animation": "heart",
-					"variant": "02",
-					"color": "random",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 0.75,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": true,
-					"unbindVisibility": true,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": false,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Charmed",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "503",
-			"label": "Chill Shield",
-			"menu": "aefx",
-			"primary": {
-				"options": {
-					"isWait": true,
-					"delay": -1000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 0,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": true,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"playOn": "source",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "ice",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"delay": -500,
-					"elevation": 1000,
-					"fadeIn": 500,
-					"fadeOut": 0,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "intro",
-					"variant": "02",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"secondary": {
-				"options": {
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"opacity": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "outro_explode",
-					"variant": "02",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"enable": false
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"soundOnly": {
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"activeEffectType": "ontoken",
-			"metaData": {
-				"label": "Chill Shield",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "504",
+			"id": "512",
 			"label": "Deafened",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -99241,284 +100900,21 @@
 				"label": "Deafened",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "505",
-			"label": "Fire Shield",
-			"menu": "aefx",
-			"primary": {
-				"options": {
-					"isWait": true,
-					"delay": -1000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 0,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": true,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"playOn": "source",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "loop",
-					"variant": "02",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"source": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"delay": -500,
-					"elevation": 1000,
-					"fadeIn": 500,
-					"fadeOut": 0,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "intro",
-					"variant": "02",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"secondary": {
-				"options": {
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"opacity": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "outro_explode",
-					"variant": "02",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"enable": true
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"soundOnly": {
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"activeEffectType": "ontoken",
-			"metaData": {
-				"label": "Fire Shield",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "506",
-			"label": "Frightened",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "conditions",
-					"animation": "horror",
-					"variant": "02",
-					"color": "random",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 0.75,
-					"playOn": "source",
-					"repeat": 3,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": true,
-					"unbindVisibility": true,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Frightened",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "507",
+			"id": "513",
 			"label": "Grappled",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -99652,419 +101048,21 @@
 				"label": "Grappled",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "508",
-			"label": "Incapacitated",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "conditions",
-					"animation": "crackedshield",
-					"variant": "01",
-					"color": "darkred",
-					"enableCustom": true,
-					"customPath": "jb2a.fireflies.many.01.blue"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": true,
-					"unbindVisibility": true,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Incapacitated",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "509",
-			"label": "Mage Armor",
-			"menu": "aefx",
-			"secondary": {
-				"enable": false,
-				"options": {},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue"
-				}
-			},
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"alpha": false,
-					"alphaMax": 0.5,
-					"alphaMin": -0.5,
-					"alphaDuration": 1000,
-					"breath": false,
-					"breathMax": 1.05,
-					"breathMin": 0.95,
-					"breathDuration": 1000,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isRadius": true,
-					"isWait": true,
-					"opacity": 0.5,
-					"playOn": "source",
-					"size": 0.61,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"tintSaturate": 0,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-short-4.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"animation": "energyfield",
-					"color": "blue",
-					"customPath": "",
-					"dbSection": "static",
-					"enableCustom": false,
-					"menuType": "shieldfx",
-					"variant": "01"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"soundOnly": {
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"activeEffectType": "aura",
-			"metaData": {
-				"label": "Mage Armor",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "510",
-			"label": "Paralyzed",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "conditions",
-					"animation": "stun",
-					"variant": "02",
-					"color": "random",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": true,
-					"unbindVisibility": true,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Paralyzed",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "511",
+			"id": "514",
 			"label": "Poisoned",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -100198,13 +101196,22 @@
 				"label": "Poisoned",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		},
 		{
-			"id": "512",
-			"label": "Prone",
+			"id": "515",
+			"label": "Charmed",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
 			"macro": {
@@ -100214,148 +101221,9 @@
 			"primary": {
 				"video": {
 					"dbSection": "static",
-					"menuType": "generic",
-					"animation": "indicator",
-					"variant": "07",
-					"color": "red",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5,0.6",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 0.75,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 0.75,
-					"unbindAlpha": true,
-					"unbindVisibility": true,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Prone",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "513",
-			"label": "Restrained",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "chains",
-					"animation": "standard",
-					"variant": "complete",
+					"menuType": "conditions",
+					"animation": "heart",
+					"variant": "02",
 					"color": "random",
 					"enableCustom": false,
 					"customPath": ""
@@ -100370,13 +101238,13 @@
 					"isMasked": false,
 					"isRadius": false,
 					"isWait": false,
-					"opacity": 0.5,
+					"opacity": 0.75,
 					"persistent": true,
 					"playbackRate": 0.75,
 					"playOn": "source",
 					"repeat": 1,
 					"repeatDelay": 250,
-					"size": 1.5,
+					"size": 1,
 					"unbindAlpha": true,
 					"unbindVisibility": true,
 					"zIndex": 1
@@ -100472,16 +101340,174 @@
 					"zIndex": 1
 				}
 			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
 			"metaData": {
-				"label": "Restrained",
+				"label": "Charmed",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
 			}
 		},
 		{
-			"id": "514",
+			"id": "516",
+			"label": "Stunned",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "conditions",
+					"animation": "dizzystars",
+					"variant": "01",
+					"color": "random",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 2000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 0.7,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 8000,
+					"size": 0.6,
+					"unbindAlpha": true,
+					"unbindVisibility": true,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1,
+					"rotateSource": false
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Stunned",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			}
+		},
+		{
+			"id": "517",
 			"label": "Shield",
 			"menu": "aefx",
 			"primary": {
@@ -100623,9 +101649,8 @@
 			}
 		},
 		{
-			"id": "515",
-			"label": "Stunned",
-			"activeEffectType": "ontoken",
+			"id": "518",
+			"label": "Bless",
 			"menu": "aefx",
 			"macro": {
 				"enable": false,
@@ -100634,309 +101659,57 @@
 			"primary": {
 				"video": {
 					"dbSection": "static",
-					"menuType": "conditions",
-					"animation": "dizzystars",
-					"variant": "01",
-					"color": "random",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 2000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 0.7,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 8000,
-					"size": 0.6,
-					"unbindAlpha": true,
-					"unbindVisibility": true,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
 					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
+					"animation": "bless",
+					"variant": "loop",
+					"color": "yellow",
 					"enableCustom": false,
 					"customPath": ""
 				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
 				"options": {
 					"addTokenWidth": false,
-					"anchor": "0.5",
+					"alpha": false,
+					"alphaMax": 0.5,
+					"alphaMin": -0.5,
+					"alphaDuration": 1000,
+					"breath": false,
+					"breathMax": 1.05,
+					"breathMin": 0.95,
+					"breathDuration": 1000,
 					"delay": 0,
 					"elevation": 1000,
 					"fadeIn": 250,
 					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1,
-					"rotateSource": false
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": false,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Stunned",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "516",
-			"label": "Unconscious",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "conditions",
-					"animation": "skull",
-					"variant": "02",
-					"color": "purple",
-					"enableCustom": true,
-					"customPath": "jb2a.glint.yellow.many.3"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
 					"isRadius": false,
 					"isWait": false,
 					"opacity": 1,
-					"persistent": true,
 					"playbackRate": 1,
 					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
 					"size": 1,
-					"unbindAlpha": true,
-					"unbindVisibility": true,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Unconscious",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "517",
-			"label": "Warm Shield",
-			"menu": "aefx",
-			"primary": {
-				"options": {
-					"isWait": true,
-					"delay": -1000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 0,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": true,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"playOn": "source",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"tintSaturate": 0,
 					"unbindAlpha": false,
 					"unbindVisibility": false,
 					"zIndex": 1
 				},
 				"sound": {
-					"delay": 0,
 					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-continuous-1.mp3"
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
 					"startTime": 0,
 					"repeat": 1,
 					"repeatDelay": 250,
@@ -100944,12 +101717,20 @@
 				},
 				"video": {
 					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "fire",
+					"menuType": "spell",
+					"animation": "curewounds",
 					"variant": "01",
-					"color": "orange",
+					"color": "blue",
 					"enableCustom": false,
 					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75
 				}
 			},
 			"source": {
@@ -100957,9 +101738,9 @@
 				"options": {
 					"addTokenWidth": false,
 					"delay": -500,
-					"elevation": 1000,
-					"fadeIn": 500,
-					"fadeOut": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
 					"isMasked": false,
 					"isRadius": false,
 					"isWait": true,
@@ -100980,27 +101761,187 @@
 				},
 				"video": {
 					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "intro",
-					"variant": "02",
-					"color": "red",
+					"menuType": "spell",
+					"animation": "bless",
+					"variant": "intro",
+					"color": "blue",
 					"enableCustom": false,
 					"customPath": ""
 				}
 			},
-			"secondary": {
+			"activeEffectType": "aura",
+			"metaData": {
+				"label": "Bless",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "519",
+			"label": "Prone",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "indicator",
+					"variant": "07",
+					"color": "red",
+					"enableCustom": false,
+					"customPath": ""
+				},
 				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5,0.6",
 					"delay": 0,
 					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
 					"isMasked": false,
 					"isRadius": false,
 					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 0.75,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 0.75,
+					"unbindAlpha": true,
+					"unbindVisibility": true,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
 					"repeat": 1,
 					"repeatDelay": 250,
 					"size": 1,
-					"opacity": 1,
 					"zIndex": 1
-				},
+				}
+			},
+			"metaData": {
+				"label": "Prone",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			}
+		},
+		{
+			"id": "520",
+			"label": "Bane",
+			"menu": "aefx",
+			"secondary": {
+				"enable": false,
+				"options": {},
 				"sound": {
 					"delay": 0,
 					"enable": false,
@@ -101012,14 +101953,57 @@
 				},
 				"video": {
 					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "outro_explode",
-					"variant": "02",
-					"color": "red",
-					"enableCustom": false,
-					"customPath": ""
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue"
+				}
+			},
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"alpha": false,
+					"alphaMax": 0.5,
+					"alphaMin": -0.5,
+					"alphaDuration": 1000,
+					"breath": false,
+					"breathMax": 1.05,
+					"breathMin": 0.95,
+					"breathDuration": 1000,
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isRadius": true,
+					"isWait": true,
+					"opacity": 0.75,
+					"playOn": "source",
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"tintSaturate": 0,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
 				},
-				"enable": false
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-8.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"animation": "bless",
+					"color": "purple",
+					"customPath": "",
+					"dbSection": "static",
+					"enableCustom": false,
+					"menuType": "spell",
+					"variant": "loop"
+				}
 			},
 			"macro": {
 				"enable": false,
@@ -101034,13 +102018,59 @@
 					"volume": 0.75
 				}
 			},
-			"activeEffectType": "ontoken",
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"activeEffectType": "aura",
 			"metaData": {
-				"label": "Warm Shield",
+				"label": "Bane",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "1.2.0",
-				"version": 5
+				"moduleVersion": "1.2.1",
+				"version": 6
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
 			}
 		}
 	],


### PR DESCRIPTION
Enabled Force Exact Match in almost all Auras, Presets, and Active Effects to prevent accidentally triggering them

Set the Token Alpha value to 0.01 for all Teleportation Preset spells (Dimension Door, Misty Step, etc) to prevent tokens turning invisible for some people

New Animations for:
Deflect Missiles
Stunning Strike
Quickened Healing