### PR TITLE
D&D5e Animations 2.1.0 (now out of beta!)

### DIFF
--- a/module/autorec.json
+++ b/module/autorec.json
@@ -19829,11 +19829,915 @@
 				"moduleVersion": "2.0.0",
 				"version": 1740566308509
 			}
+		},
+		{
+			"id": "86",
+			"label": "Force-Empowered Rend",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_generic.slash.02.002.purple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Force-Empowered Rend",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "87",
+			"label": "Nodachi",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"name": "Compendium.dnd5e-animations.Macros.Advanced Melee Attack Macro",
+				"args": "{\n    weaponGroup: 'melee_attack.04',\n    weapon: 'katana.01',\n    enableTrail: false,\n    trail: 'trail.04',\n    color: 'blue',\n\t\n    enableSound: true,\n    soundFileMelee: 'modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*',\n    delaySound: 100\n}",
+				"playWhen": "2"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.05.nodachi"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 300,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Nodachi",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "88",
+			"label": "Pan",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"name": "Compendium.dnd5e-animations.Macros.Advanced Melee Attack Macro",
+				"args": "{\n    weaponGroup: 'melee_attack.04',\n    weapon: 'katana.01',\n    enableTrail: false,\n    trail: 'trail.04',\n    color: 'blue',\n\t\n    enableSound: true,\n    soundFileMelee: 'modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*',\n    delaySound: 100\n}",
+				"playWhen": "2"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.pan.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 300,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Bludgeoning/melee-impact-metal-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 1000,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Pan",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "89",
+			"label": "Primal Savagery",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_generic.creature_attack.claw.001.green"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Acid/acid-bubbling-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 500,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 0.75,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Primal Savagery",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
 		}
 	],
 	"range": [
 		{
-			"id": "86",
+			"id": "90",
 			"label": "Acid Arrow",
 			"levels3d": {
 				"enable": true,
@@ -20079,7 +20983,7 @@
 			}
 		},
 		{
-			"id": "87",
+			"id": "91",
 			"label": "Alchemist's",
 			"levels3d": {
 				"enable": true,
@@ -20325,7 +21229,7 @@
 			}
 		},
 		{
-			"id": "88",
+			"id": "92",
 			"label": "Antimatter Rifle",
 			"levels3d": {
 				"type": "explosion",
@@ -20529,7 +21433,7 @@
 			}
 		},
 		{
-			"id": "89",
+			"id": "93",
 			"label": "Antipathy/Sympathy",
 			"levels3d": {
 				"enable": true,
@@ -20766,7 +21670,7 @@
 			}
 		},
 		{
-			"id": "90",
+			"id": "94",
 			"label": "Arcane Burst",
 			"levels3d": {
 				"enable": true,
@@ -21002,7 +21906,7 @@
 			}
 		},
 		{
-			"id": "91",
+			"id": "95",
 			"label": "Automatic",
 			"levels3d": {
 				"type": "explosion",
@@ -21205,7 +22109,7 @@
 			}
 		},
 		{
-			"id": "92",
+			"id": "96",
 			"label": "Awakened Mind",
 			"levels3d": {
 				"type": "explosion",
@@ -21408,7 +22312,7 @@
 			}
 		},
 		{
-			"id": "93",
+			"id": "97",
 			"label": "Beam",
 			"levels3d": {
 				"type": "projectile",
@@ -21617,7 +22521,7 @@
 			}
 		},
 		{
-			"id": "94",
+			"id": "98",
 			"label": "Befuddlement",
 			"levels3d": {
 				"type": "explosion",
@@ -21821,7 +22725,7 @@
 			}
 		},
 		{
-			"id": "95",
+			"id": "99",
 			"label": "Beguiling Defenses",
 			"levels3d": {
 				"type": "explosion",
@@ -22025,7 +22929,7 @@
 			}
 		},
 		{
-			"id": "96",
+			"id": "100",
 			"label": "Blood Drain",
 			"levels3d": {
 				"type": "jb2aexplosion",
@@ -22233,7 +23137,7 @@
 			}
 		},
 		{
-			"id": "97",
+			"id": "101",
 			"label": "Blowgun",
 			"levels3d": {
 				"type": "explosion",
@@ -22436,7 +23340,7 @@
 			}
 		},
 		{
-			"id": "98",
+			"id": "102",
 			"label": "Bomb",
 			"levels3d": {
 				"enable": true,
@@ -22670,7 +23574,7 @@
 			}
 		},
 		{
-			"id": "99",
+			"id": "103",
 			"label": "Boomerang",
 			"levels3d": {
 				"type": "explosion",
@@ -22873,7 +23777,7 @@
 			}
 		},
 		{
-			"id": "100",
+			"id": "104",
 			"label": "Boulder",
 			"levels3d": {
 				"enable": true,
@@ -23111,7 +24015,7 @@
 			}
 		},
 		{
-			"id": "101",
+			"id": "105",
 			"label": "Bow",
 			"levels3d": {
 				"type": "explosion",
@@ -23314,7 +24218,7 @@
 			}
 		},
 		{
-			"id": "102",
+			"id": "106",
 			"label": "Burnt Othur Fumes",
 			"levels3d": {
 				"type": "explosion",
@@ -23518,7 +24422,7 @@
 			}
 		},
 		{
-			"id": "103",
+			"id": "107",
 			"label": "Catapult",
 			"levels3d": {
 				"enable": true,
@@ -23754,7 +24658,7 @@
 			}
 		},
 		{
-			"id": "104",
+			"id": "108",
 			"label": "Catapult Munition",
 			"levels3d": {
 				"type": "explosion",
@@ -23957,7 +24861,7 @@
 			}
 		},
 		{
-			"id": "105",
+			"id": "109",
 			"label": "Chain Lightning",
 			"levels3d": {
 				"enable": true,
@@ -24200,7 +25104,7 @@
 			}
 		},
 		{
-			"id": "106",
+			"id": "110",
 			"label": "Chakram",
 			"levels3d": {
 				"enable": true,
@@ -24435,7 +25339,7 @@
 			}
 		},
 		{
-			"id": "107",
+			"id": "111",
 			"label": "Chaos Bolt",
 			"levels3d": {
 				"enable": true,
@@ -24676,7 +25580,7 @@
 			}
 		},
 		{
-			"id": "108",
+			"id": "112",
 			"label": "Chromatic Orb",
 			"levels3d": {
 				"enable": true,
@@ -24914,7 +25818,7 @@
 			}
 		},
 		{
-			"id": "109",
+			"id": "113",
 			"label": "Contagion",
 			"levels3d": {
 				"type": "castingsign",
@@ -25129,7 +26033,7 @@
 			}
 		},
 		{
-			"id": "110",
+			"id": "114",
 			"label": "Crossbow",
 			"levels3d": {
 				"type": "explosion",
@@ -25332,7 +26236,7 @@
 			}
 		},
 		{
-			"id": "111",
+			"id": "115",
 			"label": "Danse Macabre",
 			"levels3d": {
 				"type": "explosion",
@@ -25538,7 +26442,7 @@
 			}
 		},
 		{
-			"id": "112",
+			"id": "116",
 			"label": "Dart",
 			"levels3d": {
 				"type": "explosion",
@@ -25741,7 +26645,7 @@
 			}
 		},
 		{
-			"id": "113",
+			"id": "117",
 			"label": "Disintegrate",
 			"levels3d": {
 				"enable": true,
@@ -25980,7 +26884,7 @@
 			}
 		},
 		{
-			"id": "114",
+			"id": "118",
 			"label": "Draining Kiss",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -26190,7 +27094,7 @@
 			}
 		},
 		{
-			"id": "115",
+			"id": "119",
 			"label": "Dynamite",
 			"levels3d": {
 				"enable": true,
@@ -26426,7 +27330,7 @@
 			}
 		},
 		{
-			"id": "116",
+			"id": "120",
 			"label": "Eldritch Blast",
 			"levels3d": {
 				"type": "explosion",
@@ -26629,7 +27533,7 @@
 			}
 		},
 		{
-			"id": "117",
+			"id": "121",
 			"label": "Enemies Abound",
 			"levels3d": {
 				"type": "explosion",
@@ -26833,7 +27737,7 @@
 			}
 		},
 		{
-			"id": "118",
+			"id": "122",
 			"label": "Essence of Ether",
 			"levels3d": {
 				"type": "explosion",
@@ -27037,7 +27941,7 @@
 			}
 		},
 		{
-			"id": "119",
+			"id": "123",
 			"label": "Feeblemind",
 			"levels3d": {
 				"type": "runicray",
@@ -27246,7 +28150,7 @@
 			}
 		},
 		{
-			"id": "120",
+			"id": "124",
 			"label": "Finger of Death",
 			"levels3d": {
 				"enable": true,
@@ -27482,7 +28386,7 @@
 			}
 		},
 		{
-			"id": "121",
+			"id": "125",
 			"label": "Fire Bolt",
 			"levels3d": {
 				"type": "explosion",
@@ -27685,7 +28589,7 @@
 			}
 		},
 		{
-			"id": "122",
+			"id": "126",
 			"label": "Fire Ray",
 			"levels3d": {
 				"enable": true,
@@ -27919,7 +28823,7 @@
 			}
 		},
 		{
-			"id": "123",
+			"id": "127",
 			"label": "Fragmentation Grenade",
 			"levels3d": {
 				"enable": true,
@@ -28155,7 +29059,7 @@
 			}
 		},
 		{
-			"id": "124",
+			"id": "128",
 			"label": "Gnomengarde Grenade",
 			"levels3d": {
 				"enable": true,
@@ -28391,7 +29295,7 @@
 			}
 		},
 		{
-			"id": "125",
+			"id": "129",
 			"label": "Grave Bolt",
 			"levels3d": {
 				"type": "projectile",
@@ -28599,7 +29503,7 @@
 			}
 		},
 		{
-			"id": "126",
+			"id": "130",
 			"label": "Grenade",
 			"levels3d": {
 				"enable": true,
@@ -28835,7 +29739,7 @@
 			}
 		},
 		{
-			"id": "127",
+			"id": "131",
 			"label": "Grenade Launcher",
 			"levels3d": {
 				"enable": true,
@@ -29072,7 +29976,7 @@
 			}
 		},
 		{
-			"id": "128",
+			"id": "132",
 			"label": "Guiding Bolt",
 			"levels3d": {
 				"type": "explosion",
@@ -29276,7 +30180,7 @@
 			}
 		},
 		{
-			"id": "129",
+			"id": "133",
 			"label": "Gun",
 			"levels3d": {
 				"enable": true,
@@ -29512,7 +30416,7 @@
 			}
 		},
 		{
-			"id": "130",
+			"id": "134",
 			"label": "Holy Water",
 			"levels3d": {
 				"type": "explosion",
@@ -29716,7 +30620,7 @@
 			}
 		},
 		{
-			"id": "131",
+			"id": "135",
 			"label": "Hurl Flame",
 			"levels3d": {
 				"type": "projectile",
@@ -29925,7 +30829,7 @@
 			}
 		},
 		{
-			"id": "132",
+			"id": "136",
 			"label": "Ice Knife",
 			"levels3d": {
 				"type": "explosion",
@@ -30128,7 +31032,7 @@
 			}
 		},
 		{
-			"id": "133",
+			"id": "137",
 			"label": "Javelin",
 			"levels3d": {
 				"type": "explosion",
@@ -30331,7 +31235,7 @@
 			}
 		},
 		{
-			"id": "134",
+			"id": "138",
 			"label": "Kunai",
 			"levels3d": {
 				"enable": true,
@@ -30568,7 +31472,7 @@
 			}
 		},
 		{
-			"id": "135",
+			"id": "139",
 			"label": "Laser",
 			"levels3d": {
 				"type": "explosion",
@@ -30771,7 +31675,7 @@
 			}
 		},
 		{
-			"id": "136",
+			"id": "140",
 			"label": "Life Drain",
 			"levels3d": {
 				"type": "blackdart",
@@ -30978,7 +31882,7 @@
 			}
 		},
 		{
-			"id": "137",
+			"id": "141",
 			"label": "Life Transference",
 			"levels3d": {
 				"enable": true,
@@ -31215,7 +32119,7 @@
 			}
 		},
 		{
-			"id": "138",
+			"id": "142",
 			"label": "Lightning Lure",
 			"levels3d": {
 				"enable": true,
@@ -31456,7 +32360,7 @@
 			}
 		},
 		{
-			"id": "139",
+			"id": "143",
 			"label": "Longbow",
 			"levels3d": {
 				"type": "explosion",
@@ -31659,7 +32563,7 @@
 			}
 		},
 		{
-			"id": "140",
+			"id": "144",
 			"label": "Magic Missile",
 			"levels3d": {
 				"enable": true,
@@ -31898,7 +32802,7 @@
 			}
 		},
 		{
-			"id": "141",
+			"id": "145",
 			"label": "Magic Stone",
 			"levels3d": {
 				"enable": true,
@@ -32008,7 +32912,7 @@
 				"options": {
 					"addTokenWidth": false,
 					"anchor": "0.5",
-					"delay": 1500,
+					"delay": 2000,
 					"elevation": 1000,
 					"fadeIn": 250,
 					"fadeOut": 500,
@@ -32131,12 +33035,12 @@
 				"label": "Magic Stone",
 				"menu": "range",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
+				"moduleVersion": "2.1.0",
+				"version": "16867533014171"
 			}
 		},
 		{
-			"id": "142",
+			"id": "146",
 			"label": "Malice",
 			"levels3d": {
 				"type": "explosion",
@@ -32340,7 +33244,7 @@
 			}
 		},
 		{
-			"id": "143",
+			"id": "147",
 			"label": "Maze",
 			"levels3d": {
 				"enable": true,
@@ -32575,7 +33479,7 @@
 			}
 		},
 		{
-			"id": "144",
+			"id": "148",
 			"label": "Message",
 			"levels3d": {
 				"type": "explosion",
@@ -32778,7 +33682,7 @@
 			}
 		},
 		{
-			"id": "145",
+			"id": "149",
 			"label": "Mind Sliver",
 			"levels3d": {
 				"type": "explosion",
@@ -32981,7 +33885,7 @@
 			}
 		},
 		{
-			"id": "146",
+			"id": "150",
 			"label": "Mind Spike",
 			"levels3d": {
 				"enable": true,
@@ -33217,7 +34121,7 @@
 			}
 		},
 		{
-			"id": "147",
+			"id": "151",
 			"label": "Missile",
 			"levels3d": {
 				"type": "explosion",
@@ -33421,7 +34325,7 @@
 			}
 		},
 		{
-			"id": "148",
+			"id": "152",
 			"label": "Modify Memory",
 			"levels3d": {
 				"type": "explosion",
@@ -33626,7 +34530,7 @@
 			}
 		},
 		{
-			"id": "149",
+			"id": "153",
 			"label": "Musket",
 			"levels3d": {
 				"type": "explosion",
@@ -33829,7 +34733,7 @@
 			}
 		},
 		{
-			"id": "150",
+			"id": "154",
 			"label": "Negative Energy Flood",
 			"levels3d": {
 				"type": "explosion",
@@ -34032,7 +34936,7 @@
 			}
 		},
 		{
-			"id": "151",
+			"id": "155",
 			"label": "Pistol",
 			"levels3d": {
 				"type": "explosion",
@@ -34235,7 +35139,7 @@
 			}
 		},
 		{
-			"id": "152",
+			"id": "156",
 			"label": "Planar Binding",
 			"levels3d": {
 				"type": "explosion",
@@ -34439,7 +35343,7 @@
 			}
 		},
 		{
-			"id": "153",
+			"id": "157",
 			"label": "Poison Spray",
 			"levels3d": {
 				"type": "explosion",
@@ -34642,7 +35546,7 @@
 			}
 		},
 		{
-			"id": "154",
+			"id": "158",
 			"label": "Produce Flame",
 			"levels3d": {
 				"type": "explosion",
@@ -34846,7 +35750,7 @@
 			}
 		},
 		{
-			"id": "155",
+			"id": "159",
 			"label": "Psychic Scream",
 			"levels3d": {
 				"type": "explosion",
@@ -35049,7 +35953,7 @@
 			}
 		},
 		{
-			"id": "156",
+			"id": "160",
 			"label": "Ray",
 			"levels3d": {
 				"type": "runicray",
@@ -35258,7 +36162,7 @@
 			}
 		},
 		{
-			"id": "157",
+			"id": "161",
 			"label": "Ray of Enfeeblement",
 			"levels3d": {
 				"enable": true,
@@ -35497,7 +36401,7 @@
 			}
 		},
 		{
-			"id": "158",
+			"id": "162",
 			"label": "Ray of Frost",
 			"levels3d": {
 				"type": "explosion",
@@ -35700,7 +36604,7 @@
 			}
 		},
 		{
-			"id": "159",
+			"id": "163",
 			"label": "Ray of Sickness",
 			"levels3d": {
 				"enable": true,
@@ -35934,7 +36838,7 @@
 			}
 		},
 		{
-			"id": "160",
+			"id": "164",
 			"label": "Rend Mind",
 			"levels3d": {
 				"type": "explosion",
@@ -36137,7 +37041,7 @@
 			}
 		},
 		{
-			"id": "161",
+			"id": "165",
 			"label": "Restore Balance",
 			"levels3d": {
 				"type": "explosion",
@@ -36340,7 +37244,7 @@
 			}
 		},
 		{
-			"id": "162",
+			"id": "166",
 			"label": "Revolver",
 			"levels3d": {
 				"type": "explosion",
@@ -36543,7 +37447,7 @@
 			}
 		},
 		{
-			"id": "163",
+			"id": "167",
 			"label": "Rifle",
 			"levels3d": {
 				"type": "explosion",
@@ -36746,7 +37650,7 @@
 			}
 		},
 		{
-			"id": "164",
+			"id": "168",
 			"label": "Rock",
 			"levels3d": {
 				"enable": true,
@@ -36980,7 +37884,7 @@
 			}
 		},
 		{
-			"id": "165",
+			"id": "169",
 			"label": "Scorching Ray",
 			"levels3d": {
 				"enable": true,
@@ -37224,7 +38128,7 @@
 			}
 		},
 		{
-			"id": "166",
+			"id": "170",
 			"label": "Shocking Grasp",
 			"levels3d": {
 				"type": "explosion",
@@ -37427,7 +38331,7 @@
 			}
 		},
 		{
-			"id": "167",
+			"id": "171",
 			"label": "Shortbow",
 			"levels3d": {
 				"type": "explosion",
@@ -37630,7 +38534,7 @@
 			}
 		},
 		{
-			"id": "168",
+			"id": "172",
 			"label": "Shotgun",
 			"levels3d": {
 				"type": "explosion",
@@ -37833,7 +38737,7 @@
 			}
 		},
 		{
-			"id": "169",
+			"id": "173",
 			"label": "Shuriken",
 			"levels3d": {
 				"type": "explosion",
@@ -38036,7 +38940,7 @@
 			}
 		},
 		{
-			"id": "170",
+			"id": "174",
 			"label": "Siege Boulder",
 			"levels3d": {
 				"enable": true,
@@ -38271,7 +39175,7 @@
 			}
 		},
 		{
-			"id": "171",
+			"id": "175",
 			"label": "Sling",
 			"levels3d": {
 				"type": "explosion",
@@ -38474,7 +39378,7 @@
 			}
 		},
 		{
-			"id": "172",
+			"id": "176",
 			"label": "Smoke Grenade",
 			"levels3d": {
 				"enable": true,
@@ -38711,7 +39615,7 @@
 			}
 		},
 		{
-			"id": "173",
+			"id": "177",
 			"label": "Snow Ball",
 			"levels3d": {
 				"type": "explosion",
@@ -38914,7 +39818,7 @@
 			}
 		},
 		{
-			"id": "174",
+			"id": "178",
 			"label": "Sorcerous Burst",
 			"levels3d": {
 				"type": "explosion",
@@ -39117,7 +40021,7 @@
 			}
 		},
 		{
-			"id": "175",
+			"id": "179",
 			"label": "Soul Cage",
 			"levels3d": {
 				"type": "explosion",
@@ -39325,7 +40229,7 @@
 			}
 		},
 		{
-			"id": "176",
+			"id": "180",
 			"label": "Starry Wisp",
 			"levels3d": {
 				"type": "explosion",
@@ -39529,7 +40433,7 @@
 			}
 		},
 		{
-			"id": "177",
+			"id": "181",
 			"label": "Sun Blade",
 			"levels3d": {
 				"enable": true,
@@ -39765,7 +40669,7 @@
 			}
 		},
 		{
-			"id": "178",
+			"id": "182",
 			"label": "Tasha's Mind Whip",
 			"levels3d": {
 				"enable": true,
@@ -40002,7 +40906,7 @@
 			}
 		},
 		{
-			"id": "179",
+			"id": "183",
 			"label": "Telepathic Bond",
 			"levels3d": {
 				"enable": true,
@@ -40241,7 +41145,7 @@
 			}
 		},
 		{
-			"id": "180",
+			"id": "184",
 			"label": "Telepathic Speech",
 			"levels3d": {
 				"type": "explosion",
@@ -40444,7 +41348,7 @@
 			}
 		},
 		{
-			"id": "181",
+			"id": "185",
 			"label": "Witch Bolt",
 			"levels3d": {
 				"type": "runicray",
@@ -40661,650 +41565,1029 @@
 				"moduleVersion": "2.0.0",
 				"version": 1686753301417
 			}
+		},
+		{
+			"id": "186",
+			"label": "Antagonize",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular",
+					"enableCustom": true,
+					"customPath": "jb2a.spell_projectile.sound.01.pinkteal"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 800,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.condition.curse.01.007.purple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "psfx.cantrips.mind-sliver.v1",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.5
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Antagonize",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "187",
+			"label": "Force Ballista",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "eldritchblast",
+					"variant": "01",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "psfx.cantrips.eldritch-blast.v1",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Force Ballista",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "188",
+			"label": "Jim's Glowing Coin",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "sling",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 1000,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0.75,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": true,
+					"tintColor": "#FFD700",
+					"zIndex": 1,
+					"randomOffset": true,
+					"reverse": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Jim's Glowing Coin",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "189",
+			"label": "Lightning Launcher",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "chainlightning",
+					"variant": "primary",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Lightning/lightning-impact-6.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Lightning Launcher",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "190",
+			"label": "Thunder Gauntlet",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "chainlightning",
+					"variant": "primary",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Lightning/lightning-impact-6.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Thunder Gauntlet",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
 		}
 	],
 	"ontoken": [
 		{
-			"id": "182",
-			"label": " Branches of the Tree",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "entangle",
-					"variant": "01",
-					"color": "brown",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-plant-moving-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75,
-					"file": "modules/dnd5e-animations/assets/sounds/Creatures/Growl/growl-3.mp3"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": " Branches of the Tree",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
-			}
-		},
-		{
-			"id": "183",
-			"label": " Cutting Words",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.soundwave.02.orangepurple"
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/HuntersMark.mp3"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.soundwave.02.orangepurple"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-7.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": " Cutting Words",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
-			}
-		},
-		{
-			"id": "184",
-			"label": " Vitality of the Tree",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "generichealing",
-					"variant": "01",
-					"color": "green",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "plants",
-					"animation": "circle",
-					"variant": "complete",
-					"color": "greenyellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": " Vitality of the Tree",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
-			}
-		},
-		{
-			"id": "185",
+			"id": "191",
 			"label": "Abjure Foes",
 			"levels3d": {
 				"type": "explosion",
@@ -41517,229 +42800,7 @@
 			}
 		},
 		{
-			"id": "186",
-			"label": "Absorb Elements",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_07.webp",
-					"color01": "#00ff2a",
-					"color02": "#00ffbf",
-					"duration": 1500,
-					"life": 400,
-					"alpha": 1,
-					"onCenter": true
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.markers.bubble.loop.rainbow",
-						"type": "mysteriouslights",
-						"onCenter": true,
-						"color01": "#3197a5",
-						"color02": "#0affce"
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-blast-2.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": true,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "buff",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 500,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Bardic-Inspiration.ogg",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "bubble",
-					"variant": "complete",
-					"color": "blue",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ki.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Absorb Elements",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "187",
+			"id": "192",
 			"label": "Acid (vial)",
 			"levels3d": {
 				"type": "explosion",
@@ -41952,7 +43013,7 @@
 			}
 		},
 		{
-			"id": "188",
+			"id": "193",
 			"label": "Action Surge",
 			"levels3d": {
 				"enable": true,
@@ -42181,7 +43242,7 @@
 			}
 		},
 		{
-			"id": "189",
+			"id": "194",
 			"label": "Adrenaline Rush",
 			"levels3d": {
 				"enable": true,
@@ -42261,7 +43322,7 @@
 				"sound": {
 					"delay": 0,
 					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Rage.mp3",
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-7.mp3",
 					"startTime": 0,
 					"volume": 0.75,
 					"repeat": 1,
@@ -42410,7 +43471,7 @@
 			}
 		},
 		{
-			"id": "190",
+			"id": "195",
 			"label": "Aid",
 			"levels3d": {
 				"enable": true,
@@ -42633,7 +43694,7 @@
 			}
 		},
 		{
-			"id": "191",
+			"id": "196",
 			"label": "Air Bubble",
 			"levels3d": {
 				"type": "explosion",
@@ -42847,7 +43908,7 @@
 			}
 		},
 		{
-			"id": "192",
+			"id": "197",
 			"label": "Alter Self",
 			"levels3d": {
 				"enable": true,
@@ -43066,7 +44127,7 @@
 			}
 		},
 		{
-			"id": "193",
+			"id": "198",
 			"label": "Animal Friendship",
 			"levels3d": {
 				"enable": true,
@@ -43298,7 +44359,7 @@
 			}
 		},
 		{
-			"id": "194",
+			"id": "199",
 			"label": "Animal Messenger",
 			"levels3d": {
 				"enable": true,
@@ -43516,7 +44577,7 @@
 			}
 		},
 		{
-			"id": "195",
+			"id": "200",
 			"label": "Animal Shapes",
 			"levels3d": {
 				"type": "castingsign",
@@ -43730,7 +44791,7 @@
 			}
 		},
 		{
-			"id": "196",
+			"id": "201",
 			"label": "Animate Dead",
 			"levels3d": {
 				"enable": true,
@@ -43950,7 +45011,7 @@
 			}
 		},
 		{
-			"id": "197",
+			"id": "202",
 			"label": "Animate Objects",
 			"levels3d": {
 				"enable": true,
@@ -44170,7 +45231,7 @@
 			}
 		},
 		{
-			"id": "198",
+			"id": "203",
 			"label": "Arcane Eye",
 			"levels3d": {
 				"enable": true,
@@ -44394,7 +45455,7 @@
 			}
 		},
 		{
-			"id": "199",
+			"id": "204",
 			"label": "Arcane Gate",
 			"levels3d": {
 				"enable": true,
@@ -44616,7 +45677,7 @@
 			}
 		},
 		{
-			"id": "200",
+			"id": "205",
 			"label": "Arcane Hand",
 			"levels3d": {
 				"enable": true,
@@ -44844,7 +45905,7 @@
 			}
 		},
 		{
-			"id": "201",
+			"id": "206",
 			"label": "Arcane Lock",
 			"levels3d": {
 				"enable": true,
@@ -45060,7 +46121,7 @@
 			}
 		},
 		{
-			"id": "202",
+			"id": "207",
 			"label": "Arcane Recovery",
 			"levels3d": {
 				"enable": true,
@@ -45291,7 +46352,7 @@
 			}
 		},
 		{
-			"id": "203",
+			"id": "208",
 			"label": "Arcane Sword",
 			"levels3d": {
 				"type": "explosion",
@@ -45503,7 +46564,7 @@
 			}
 		},
 		{
-			"id": "204",
+			"id": "209",
 			"label": "Arcane Vigor",
 			"levels3d": {
 				"type": "explosion",
@@ -45716,7 +46777,7 @@
 			}
 		},
 		{
-			"id": "205",
+			"id": "210",
 			"label": "Arcane Ward",
 			"levels3d": {
 				"type": "explosion",
@@ -45928,7 +46989,7 @@
 			}
 		},
 		{
-			"id": "206",
+			"id": "211",
 			"label": "Armor of Agathys",
 			"levels3d": {
 				"enable": true,
@@ -46151,7 +47212,7 @@
 			}
 		},
 		{
-			"id": "207",
+			"id": "212",
 			"levels3d": {
 				"type": "explosion",
 				"data": {
@@ -46363,7 +47424,7 @@
 			}
 		},
 		{
-			"id": "208",
+			"id": "213",
 			"label": "Ashardalon's Stride",
 			"levels3d": {
 				"type": "explosion",
@@ -46577,7 +47638,7 @@
 			}
 		},
 		{
-			"id": "209",
+			"id": "214",
 			"label": "Assassin's Blood",
 			"levels3d": {
 				"type": "explosion",
@@ -46789,7 +47850,7 @@
 			}
 		},
 		{
-			"id": "210",
+			"id": "215",
 			"label": "Astral Projection",
 			"levels3d": {
 				"enable": true,
@@ -47011,7 +48072,7 @@
 			}
 		},
 		{
-			"id": "211",
+			"id": "216",
 			"label": "Augury",
 			"levels3d": {
 				"enable": true,
@@ -47232,7 +48293,7 @@
 			}
 		},
 		{
-			"id": "212",
+			"id": "217",
 			"label": "Awaken",
 			"levels3d": {
 				"enable": true,
@@ -47452,7 +48513,7 @@
 			}
 		},
 		{
-			"id": "213",
+			"id": "218",
 			"label": "Bane",
 			"levels3d": {
 				"type": "castingsign",
@@ -47681,7 +48742,7 @@
 			}
 		},
 		{
-			"id": "214",
+			"id": "219",
 			"label": "Banishment",
 			"levels3d": {
 				"type": "castingsign",
@@ -47898,7 +48959,7 @@
 			}
 		},
 		{
-			"id": "215",
+			"id": "220",
 			"label": "Bardic Inspiration",
 			"levels3d": {
 				"type": "vortex",
@@ -48118,7 +49179,7 @@
 			}
 		},
 		{
-			"id": "216",
+			"id": "221",
 			"label": "Beacon of Hope",
 			"levels3d": {
 				"enable": true,
@@ -48343,7 +49404,7 @@
 			}
 		},
 		{
-			"id": "217",
+			"id": "222",
 			"label": "Beast Bond",
 			"levels3d": {
 				"enable": true,
@@ -48563,7 +49624,7 @@
 			}
 		},
 		{
-			"id": "218",
+			"id": "223",
 			"label": "Beast Sense",
 			"levels3d": {
 				"enable": true,
@@ -48783,7 +49844,7 @@
 			}
 		},
 		{
-			"id": "219",
+			"id": "224",
 			"label": "Bend Luck",
 			"levels3d": {
 				"type": "explosion",
@@ -48995,7 +50056,7 @@
 			}
 		},
 		{
-			"id": "220",
+			"id": "225",
 			"label": "Bestow Curse",
 			"levels3d": {
 				"enable": true,
@@ -49222,7 +50283,7 @@
 			}
 		},
 		{
-			"id": "221",
+			"id": "226",
 			"label": "Bigby's Hand",
 			"levels3d": {
 				"enable": true,
@@ -49450,7 +50511,7 @@
 			}
 		},
 		{
-			"id": "222",
+			"id": "227",
 			"label": "Bite",
 			"levels3d": {
 				"enable": true,
@@ -49696,7 +50757,7 @@
 			}
 		},
 		{
-			"id": "223",
+			"id": "228",
 			"label": "Blade Barrier",
 			"levels3d": {
 				"type": "explosion",
@@ -49908,7 +50969,7 @@
 			}
 		},
 		{
-			"id": "224",
+			"id": "229",
 			"label": "Blade of Disaster",
 			"levels3d": {
 				"type": "explosion",
@@ -50121,7 +51182,7 @@
 			}
 		},
 		{
-			"id": "225",
+			"id": "230",
 			"label": "Blade Ward",
 			"levels3d": {
 				"type": "castingsign",
@@ -50334,7 +51395,7 @@
 			}
 		},
 		{
-			"id": "226",
+			"id": "231",
 			"label": "Bless",
 			"levels3d": {
 				"type": "castingsign",
@@ -50570,7 +51631,7 @@
 			}
 		},
 		{
-			"id": "227",
+			"id": "232",
 			"label": "Blessed Healer",
 			"levels3d": {
 				"type": "magicburst",
@@ -50787,7 +51848,7 @@
 			}
 		},
 		{
-			"id": "228",
+			"id": "233",
 			"label": "Blessed Strikes",
 			"levels3d": {
 				"enable": true,
@@ -51011,7 +52072,7 @@
 			}
 		},
 		{
-			"id": "229",
+			"id": "234",
 			"label": "Blight",
 			"levels3d": {
 				"type": "castingsign",
@@ -51227,7 +52288,7 @@
 			}
 		},
 		{
-			"id": "230",
+			"id": "235",
 			"label": "Blindness/Deafness",
 			"levels3d": {
 				"enable": true,
@@ -51447,7 +52508,7 @@
 			}
 		},
 		{
-			"id": "231",
+			"id": "236",
 			"label": "Blink",
 			"levels3d": {
 				"enable": true,
@@ -51668,7 +52729,7 @@
 			}
 		},
 		{
-			"id": "232",
+			"id": "237",
 			"label": "Booming Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -51883,7 +52944,7 @@
 			}
 		},
 		{
-			"id": "233",
+			"id": "238",
 			"label": "Borrowed Knowledge",
 			"levels3d": {
 				"type": "explosion",
@@ -51942,7 +53003,7 @@
 					"opacity": 1,
 					"persistent": false,
 					"playbackRate": 1,
-					"playOn": "default",
+					"playOn": "source",
 					"repeat": 1,
 					"repeatDelay": 250,
 					"saturate": 0,
@@ -52091,12 +53152,226 @@
 				"label": "Borrowed Knowledge",
 				"menu": "ontoken",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "234",
+			"id": "239",
+			"label": "Branches of the Tree",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "entangle",
+					"variant": "01",
+					"color": "brown",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/spell-whoosh-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Creatures/Growl/growl-3.mp3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Branches of the Tree",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.0.0",
+				"version": 1740566308510
+			}
+		},
+		{
+			"id": "240",
 			"label": "Bubbling Cauldron",
 			"levels3d": {
 				"enable": true,
@@ -52319,7 +53594,7 @@
 			}
 		},
 		{
-			"id": "235",
+			"id": "241",
 			"label": "Bulwark of Force",
 			"levels3d": {
 				"type": "explosion",
@@ -52531,7 +53806,7 @@
 			}
 		},
 		{
-			"id": "236",
+			"id": "242",
 			"label": "Catnap",
 			"levels3d": {
 				"type": "explosion",
@@ -52743,231 +54018,7 @@
 			}
 		},
 		{
-			"id": "237",
-			"label": "Cause Fear",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_13.webp",
-					"color01": "#220070",
-					"color02": "#af76d5",
-					"alpha": 1,
-					"duration": 2500,
-					"life": 400
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.toll_the_dead.purple.skull_smoke",
-						"type": "mysteriouslights",
-						"color01": "#4c00ff",
-						"color02": "#ba9fd5",
-						"onCenter": true,
-						"rate": 15,
-						"alpha": 1,
-						"duration": 2200
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": true,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "generic",
-					"animation": "ui",
-					"variant": "horror",
-					"color": "darkteal",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-2.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Cause Fear",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "238",
+			"id": "243",
 			"label": "Celestial Resilience",
 			"levels3d": {
 				"type": "explosion",
@@ -53179,7 +54230,7 @@
 			}
 		},
 		{
-			"id": "239",
+			"id": "244",
 			"label": "Celestial Revelation",
 			"levels3d": {
 				"type": "explosion",
@@ -53393,7 +54444,7 @@
 			}
 		},
 		{
-			"id": "240",
+			"id": "245",
 			"label": "Ceremony",
 			"levels3d": {
 				"type": "explosion",
@@ -53605,7 +54656,7 @@
 			}
 		},
 		{
-			"id": "241",
+			"id": "246",
 			"label": "Channel Divinity",
 			"levels3d": {
 				"type": "explosion",
@@ -53818,7 +54869,7 @@
 			}
 		},
 		{
-			"id": "242",
+			"id": "247",
 			"label": "Charm",
 			"levels3d": {
 				"type": "castingsign",
@@ -54034,7 +55085,7 @@
 			}
 		},
 		{
-			"id": "243",
+			"id": "248",
 			"label": "Charm Monster",
 			"levels3d": {
 				"type": "castingsign",
@@ -54253,7 +55304,7 @@
 			}
 		},
 		{
-			"id": "244",
+			"id": "249",
 			"label": "Charm Person",
 			"levels3d": {
 				"enable": true,
@@ -54476,7 +55527,7 @@
 			}
 		},
 		{
-			"id": "245",
+			"id": "250",
 			"label": "Children of the Night",
 			"levels3d": {
 				"type": "magicsphere",
@@ -54689,7 +55740,7 @@
 			}
 		},
 		{
-			"id": "246",
+			"id": "251",
 			"label": "Chill Touch",
 			"levels3d": {
 				"type": "explosion",
@@ -54901,7 +55952,7 @@
 			}
 		},
 		{
-			"id": "247",
+			"id": "252",
 			"label": "Clairvoyance",
 			"levels3d": {
 				"enable": true,
@@ -55126,7 +56177,7 @@
 			}
 		},
 		{
-			"id": "248",
+			"id": "253",
 			"label": "Clairvoyant Combatant",
 			"levels3d": {
 				"type": "explosion",
@@ -55338,7 +56389,7 @@
 			}
 		},
 		{
-			"id": "249",
+			"id": "254",
 			"label": "Cleansing Touch",
 			"levels3d": {
 				"enable": true,
@@ -55563,7 +56614,7 @@
 			}
 		},
 		{
-			"id": "250",
+			"id": "255",
 			"label": "Cloak of Shadows",
 			"levels3d": {
 				"type": "explosion",
@@ -55775,7 +56826,7 @@
 			}
 		},
 		{
-			"id": "251",
+			"id": "256",
 			"label": "Clone",
 			"levels3d": {
 				"type": "explosion",
@@ -55988,7 +57039,7 @@
 			}
 		},
 		{
-			"id": "252",
+			"id": "257",
 			"label": "Command",
 			"levels3d": {
 				"enable": true,
@@ -56238,7 +57289,7 @@
 			}
 		},
 		{
-			"id": "253",
+			"id": "258",
 			"label": "Commune",
 			"levels3d": {
 				"enable": true,
@@ -56457,7 +57508,7 @@
 			}
 		},
 		{
-			"id": "254",
+			"id": "259",
 			"label": "Commune with Nature",
 			"levels3d": {
 				"type": "castingsign",
@@ -56673,7 +57724,7 @@
 			}
 		},
 		{
-			"id": "255",
+			"id": "260",
 			"label": "Compelled Duel",
 			"levels3d": {
 				"enable": true,
@@ -56896,7 +57947,7 @@
 			}
 		},
 		{
-			"id": "256",
+			"id": "261",
 			"label": "Comprehend Languages",
 			"levels3d": {
 				"enable": true,
@@ -57117,7 +58168,7 @@
 			}
 		},
 		{
-			"id": "257",
+			"id": "262",
 			"label": "Compulsion",
 			"levels3d": {
 				"type": "castingsign",
@@ -57331,7 +58382,7 @@
 			}
 		},
 		{
-			"id": "258",
+			"id": "263",
 			"label": "Confusion",
 			"levels3d": {
 				"enable": true,
@@ -57547,7 +58598,7 @@
 			}
 		},
 		{
-			"id": "259",
+			"id": "264",
 			"label": "Conjure Animals",
 			"levels3d": {
 				"enable": true,
@@ -57767,7 +58818,7 @@
 			}
 		},
 		{
-			"id": "260",
+			"id": "265",
 			"label": "Conjure Elemental",
 			"levels3d": {
 				"enable": true,
@@ -57987,7 +59038,7 @@
 			}
 		},
 		{
-			"id": "261",
+			"id": "266",
 			"label": "Conjure Fey",
 			"levels3d": {
 				"enable": true,
@@ -58207,7 +59258,7 @@
 			}
 		},
 		{
-			"id": "262",
+			"id": "267",
 			"label": "Constrict",
 			"levels3d": {
 				"enable": true,
@@ -58420,7 +59471,7 @@
 			}
 		},
 		{
-			"id": "263",
+			"id": "268",
 			"label": "Contact Other Plane",
 			"levels3d": {
 				"type": "castingsign",
@@ -58633,7 +59684,7 @@
 			}
 		},
 		{
-			"id": "264",
+			"id": "269",
 			"label": "Contingency",
 			"levels3d": {
 				"type": "castingsign",
@@ -58851,7 +59902,7 @@
 			}
 		},
 		{
-			"id": "265",
+			"id": "270",
 			"label": "Continual Flame",
 			"levels3d": {
 				"enable": true,
@@ -59069,7 +60120,7 @@
 			}
 		},
 		{
-			"id": "266",
+			"id": "271",
 			"label": "Control",
 			"levels3d": {
 				"type": "explosion",
@@ -59281,7 +60332,7 @@
 			}
 		},
 		{
-			"id": "267",
+			"id": "272",
 			"label": "Control Weather",
 			"levels3d": {
 				"type": "explosion",
@@ -59494,7 +60545,7 @@
 			}
 		},
 		{
-			"id": "268",
+			"id": "273",
 			"label": "Controlled Chaos",
 			"levels3d": {
 				"type": "explosion",
@@ -59706,7 +60757,7 @@
 			}
 		},
 		{
-			"id": "269",
+			"id": "274",
 			"label": "Cordon of Arrows",
 			"levels3d": {
 				"type": "castingsign",
@@ -59920,7 +60971,7 @@
 			}
 		},
 		{
-			"id": "270",
+			"id": "275",
 			"label": "Cosmic Omen",
 			"levels3d": {
 				"type": "explosion",
@@ -60132,7 +61183,7 @@
 			}
 		},
 		{
-			"id": "271",
+			"id": "276",
 			"label": "Countercharm",
 			"levels3d": {
 				"enable": true,
@@ -60351,7 +61402,7 @@
 			}
 		},
 		{
-			"id": "272",
+			"id": "277",
 			"label": "Counterspell",
 			"levels3d": {
 				"enable": true,
@@ -60573,7 +61624,7 @@
 			}
 		},
 		{
-			"id": "273",
+			"id": "278",
 			"label": "Crawler Mucus",
 			"levels3d": {
 				"type": "explosion",
@@ -60785,7 +61836,7 @@
 			}
 		},
 		{
-			"id": "274",
+			"id": "279",
 			"label": "Create Food and Water",
 			"levels3d": {
 				"enable": true,
@@ -61006,7 +62057,7 @@
 			}
 		},
 		{
-			"id": "275",
+			"id": "280",
 			"label": "Create Homunculus",
 			"levels3d": {
 				"type": "explosion",
@@ -61219,7 +62270,7 @@
 			}
 		},
 		{
-			"id": "276",
+			"id": "281",
 			"label": "Create Spelljamming Helm",
 			"levels3d": {
 				"type": "explosion",
@@ -61432,7 +62483,7 @@
 			}
 		},
 		{
-			"id": "277",
+			"id": "282",
 			"label": "Create Undead",
 			"levels3d": {
 				"type": "castingsign",
@@ -61647,7 +62698,7 @@
 			}
 		},
 		{
-			"id": "278",
+			"id": "283",
 			"label": "Crown of Stars",
 			"levels3d": {
 				"type": "explosion",
@@ -61860,7 +62911,7 @@
 			}
 		},
 		{
-			"id": "279",
+			"id": "284",
 			"label": "Cunning Action",
 			"levels3d": {
 				"type": "explosion",
@@ -62072,7 +63123,7 @@
 			}
 		},
 		{
-			"id": "280",
+			"id": "285",
 			"label": "Cunning Strike",
 			"levels3d": {
 				"type": "explosion",
@@ -62284,7 +63335,7 @@
 			}
 		},
 		{
-			"id": "281",
+			"id": "286",
 			"label": "Cure Wounds",
 			"levels3d": {
 				"enable": true,
@@ -62539,7 +63590,220 @@
 			}
 		},
 		{
-			"id": "282",
+			"id": "287",
+			"label": "Cutting Words",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.soundwave.02.orangepurple"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/HuntersMark.mp3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.soundwave.02.orangepurple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-7.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Cutting Words",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.0.0",
+				"version": 1740566308510
+			}
+		},
+		{
+			"id": "288",
 			"label": "Dancing Lights",
 			"levels3d": {
 				"type": "explosion",
@@ -62751,7 +64015,7 @@
 			}
 		},
 		{
-			"id": "283",
+			"id": "289",
 			"label": "Dark One's Blessing",
 			"levels3d": {
 				"type": "explosion",
@@ -62963,7 +64227,7 @@
 			}
 		},
 		{
-			"id": "284",
+			"id": "290",
 			"label": "Dark One's Own Luck",
 			"levels3d": {
 				"type": "explosion",
@@ -63177,7 +64441,7 @@
 			}
 		},
 		{
-			"id": "285",
+			"id": "291",
 			"label": "Darkvision",
 			"levels3d": {
 				"enable": true,
@@ -63400,7 +64664,7 @@
 			}
 		},
 		{
-			"id": "286",
+			"id": "292",
 			"label": "Death Strike",
 			"levels3d": {
 				"type": "explosion",
@@ -63614,7 +64878,7 @@
 			}
 		},
 		{
-			"id": "287",
+			"id": "293",
 			"label": "Death Ward",
 			"levels3d": {
 				"enable": true,
@@ -63832,7 +65096,7 @@
 			}
 		},
 		{
-			"id": "288",
+			"id": "294",
 			"label": "Defense Roll",
 			"levels3d": {
 				"type": "magicsphere",
@@ -64047,7 +65311,7 @@
 			}
 		},
 		{
-			"id": "289",
+			"id": "295",
 			"label": "Defensive Tactics",
 			"levels3d": {
 				"type": "explosion",
@@ -64259,7 +65523,7 @@
 			}
 		},
 		{
-			"id": "290",
+			"id": "296",
 			"label": "Deflect Missiles",
 			"levels3d": {
 				"type": "explosion",
@@ -64491,7 +65755,7 @@
 			}
 		},
 		{
-			"id": "291",
+			"id": "297",
 			"label": "Demiplane",
 			"levels3d": {
 				"enable": true,
@@ -64713,7 +65977,7 @@
 			}
 		},
 		{
-			"id": "292",
+			"id": "298",
 			"label": "Detect Thoughts",
 			"levels3d": {
 				"enable": true,
@@ -64931,7 +66195,7 @@
 			}
 		},
 		{
-			"id": "293",
+			"id": "299",
 			"label": "Devious Strikes",
 			"levels3d": {
 				"type": "explosion",
@@ -65143,7 +66407,7 @@
 			}
 		},
 		{
-			"id": "294",
+			"id": "300",
 			"label": "Disciplined Survivor",
 			"levels3d": {
 				"type": "explosion",
@@ -65355,7 +66619,7 @@
 			}
 		},
 		{
-			"id": "295",
+			"id": "301",
 			"label": "Disguise Self",
 			"levels3d": {
 				"enable": true,
@@ -65577,7 +66841,7 @@
 			}
 		},
 		{
-			"id": "296",
+			"id": "302",
 			"label": "Dispel Evil and Good",
 			"levels3d": {
 				"type": "castingsign",
@@ -65789,7 +67053,7 @@
 			}
 		},
 		{
-			"id": "297",
+			"id": "303",
 			"label": "Dispel Magic",
 			"levels3d": {
 				"enable": true,
@@ -66008,7 +67272,7 @@
 			}
 		},
 		{
-			"id": "298",
+			"id": "304",
 			"label": "Dissonant Whispers",
 			"levels3d": {
 				"enable": true,
@@ -66236,7 +67500,7 @@
 			}
 		},
 		{
-			"id": "299",
+			"id": "305",
 			"label": "Divination",
 			"levels3d": {
 				"enable": true,
@@ -66465,7 +67729,7 @@
 			}
 		},
 		{
-			"id": "300",
+			"id": "306",
 			"label": "Divine Favor",
 			"levels3d": {
 				"enable": true,
@@ -66690,7 +67954,7 @@
 			}
 		},
 		{
-			"id": "301",
+			"id": "307",
 			"label": "Divine Intervention",
 			"levels3d": {
 				"enable": true,
@@ -66911,7 +68175,7 @@
 			}
 		},
 		{
-			"id": "302",
+			"id": "308",
 			"label": "Divine Sense",
 			"levels3d": {
 				"type": "explosion",
@@ -67123,7 +68387,7 @@
 			}
 		},
 		{
-			"id": "303",
+			"id": "309",
 			"label": "Divine Smite",
 			"levels3d": {
 				"enable": true,
@@ -67344,7 +68608,7 @@
 			}
 		},
 		{
-			"id": "304",
+			"id": "310",
 			"label": "Divine Strike",
 			"levels3d": {
 				"enable": true,
@@ -67569,7 +68833,7 @@
 			}
 		},
 		{
-			"id": "305",
+			"id": "311",
 			"label": "Divine Word",
 			"levels3d": {
 				"type": "castingsign",
@@ -67787,7 +69051,7 @@
 			}
 		},
 		{
-			"id": "306",
+			"id": "312",
 			"label": "Dominate Beast",
 			"levels3d": {
 				"enable": true,
@@ -68008,7 +69272,7 @@
 			}
 		},
 		{
-			"id": "307",
+			"id": "313",
 			"label": "Dominate Monster",
 			"levels3d": {
 				"enable": true,
@@ -68229,7 +69493,7 @@
 			}
 		},
 		{
-			"id": "308",
+			"id": "314",
 			"label": "Dominate Person",
 			"levels3d": {
 				"enable": true,
@@ -68450,7 +69714,7 @@
 			}
 		},
 		{
-			"id": "309",
+			"id": "315",
 			"label": "Dominate-disable",
 			"levels3d": {
 				"enable": true,
@@ -68671,7 +69935,7 @@
 			}
 		},
 		{
-			"id": "310",
+			"id": "316",
 			"label": "Draconic Flight",
 			"levels3d": {
 				"type": "explosion",
@@ -68887,219 +70151,7 @@
 			}
 		},
 		{
-			"id": "311",
-			"label": "Draconic Transformation",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "fire",
-					"variant": "03",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-breath-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "red",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Draconic Transformation",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "312",
+			"id": "317",
 			"label": "Dread Ambusher",
 			"levels3d": {
 				"type": "explosion",
@@ -69311,7 +70363,7 @@
 			}
 		},
 		{
-			"id": "313",
+			"id": "318",
 			"label": "Dreadful Strikes",
 			"levels3d": {
 				"type": "explosion",
@@ -69523,7 +70575,7 @@
 			}
 		},
 		{
-			"id": "314",
+			"id": "319",
 			"label": "Dream",
 			"levels3d": {
 				"enable": true,
@@ -69745,7 +70797,7 @@
 			}
 		},
 		{
-			"id": "315",
+			"id": "320",
 			"label": "Dream of the Blue Veil",
 			"levels3d": {
 				"enable": true,
@@ -69967,7 +71019,7 @@
 			}
 		},
 		{
-			"id": "316",
+			"id": "321",
 			"label": "Drow Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -70179,7 +71231,7 @@
 			}
 		},
 		{
-			"id": "317",
+			"id": "322",
 			"label": "Druid Grove",
 			"levels3d": {
 				"type": "explosion",
@@ -70391,7 +71443,7 @@
 			}
 		},
 		{
-			"id": "318",
+			"id": "323",
 			"label": "Druidcraft",
 			"levels3d": {
 				"type": "explosion",
@@ -70603,7 +71655,7 @@
 			}
 		},
 		{
-			"id": "319",
+			"id": "324",
 			"label": "Earth Tremor",
 			"levels3d": {
 				"type": "explosion",
@@ -70817,7 +71869,7 @@
 			}
 		},
 		{
-			"id": "320",
+			"id": "325",
 			"label": "Earthbind",
 			"levels3d": {
 				"type": "explosion",
@@ -71029,7 +72081,7 @@
 			}
 		},
 		{
-			"id": "321",
+			"id": "326",
 			"label": "Earthquake",
 			"levels3d": {
 				"type": "explosion",
@@ -71244,7 +72296,7 @@
 			}
 		},
 		{
-			"id": "322",
+			"id": "327",
 			"label": "Eldritch Master",
 			"levels3d": {
 				"type": "explosion",
@@ -71456,7 +72508,7 @@
 			}
 		},
 		{
-			"id": "323",
+			"id": "328",
 			"label": "Eldritch Smite",
 			"levels3d": {
 				"enable": true,
@@ -71678,7 +72730,7 @@
 			}
 		},
 		{
-			"id": "324",
+			"id": "329",
 			"label": "Elemental Affinity",
 			"levels3d": {
 				"type": "explosion",
@@ -71890,7 +72942,7 @@
 			}
 		},
 		{
-			"id": "325",
+			"id": "330",
 			"label": "Elemental Attunement",
 			"levels3d": {
 				"type": "explosion",
@@ -72102,7 +73154,7 @@
 			}
 		},
 		{
-			"id": "326",
+			"id": "331",
 			"label": "Elemental Weapon",
 			"levels3d": {
 				"enable": true,
@@ -72321,7 +73373,7 @@
 			}
 		},
 		{
-			"id": "327",
+			"id": "332",
 			"label": "Empowered Evocation",
 			"levels3d": {
 				"type": "explosion",
@@ -72533,7 +73585,7 @@
 			}
 		},
 		{
-			"id": "328",
+			"id": "333",
 			"label": "Empty Body",
 			"levels3d": {
 				"type": "explosion",
@@ -72745,236 +73797,7 @@
 			}
 		},
 		{
-			"id": "329",
-			"label": "Encode Thoughts",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_12.webp",
-					"color01": "#da98ec",
-					"color02": "#0023d1",
-					"duration": 1500,
-					"onCenter": true,
-					"alpha": 1
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.magic_signs.rune.enchantment.complete.purple",
-						"type": "magicsphere",
-						"color01": "#bfedf3",
-						"color02": "#ff00f7",
-						"onCenter": true,
-						"rate": 5,
-						"alpha": 1,
-						"scale": 2,
-						"gravity": 1,
-						"duration": 3500,
-						"life": 1000
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "shake",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"playbackRate": 2
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "enchantment",
-					"variant": "runecomplete",
-					"color": "pink",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Encode Thoughts",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "330",
+			"id": "334",
 			"label": "Enhance Ability",
 			"levels3d": {
 				"enable": true,
@@ -73220,7 +74043,7 @@
 			}
 		},
 		{
-			"id": "331",
+			"id": "335",
 			"label": "Enlarge/Reduce",
 			"levels3d": {
 				"type": "castingsign",
@@ -73434,7 +74257,7 @@
 			}
 		},
 		{
-			"id": "332",
+			"id": "336",
 			"label": "Ensnaring Strike",
 			"levels3d": {
 				"enable": true,
@@ -73660,7 +74483,7 @@
 			}
 		},
 		{
-			"id": "333",
+			"id": "337",
 			"label": "Enthrall",
 			"levels3d": {
 				"enable": true,
@@ -73882,7 +74705,7 @@
 			}
 		},
 		{
-			"id": "334",
+			"id": "338",
 			"label": "Envenom Weapons",
 			"levels3d": {
 				"type": "explosion",
@@ -74094,7 +74917,7 @@
 			}
 		},
 		{
-			"id": "335",
+			"id": "339",
 			"label": "Ethereal Sight",
 			"levels3d": {
 				"enable": true,
@@ -74318,7 +75141,7 @@
 			}
 		},
 		{
-			"id": "336",
+			"id": "340",
 			"label": "Etherealness",
 			"levels3d": {
 				"enable": true,
@@ -74537,7 +75360,7 @@
 			}
 		},
 		{
-			"id": "337",
+			"id": "341",
 			"label": "Euphoria Breath",
 			"levels3d": {
 				"type": "directionalfire",
@@ -74749,7 +75572,7 @@
 			}
 		},
 		{
-			"id": "338",
+			"id": "342",
 			"label": "Expeditious Retreat",
 			"levels3d": {
 				"enable": true,
@@ -75002,7 +75825,7 @@
 			}
 		},
 		{
-			"id": "339",
+			"id": "343",
 			"levels3d": {
 				"type": "slash",
 				"data": {
@@ -75215,7 +76038,7 @@
 			}
 		},
 		{
-			"id": "340",
+			"id": "344",
 			"label": "Eyebite",
 			"levels3d": {
 				"type": "castingsign",
@@ -75430,7 +76253,7 @@
 			}
 		},
 		{
-			"id": "341",
+			"id": "345",
 			"label": "Fabricate",
 			"levels3d": {
 				"type": "explosion",
@@ -75643,7 +76466,7 @@
 			}
 		},
 		{
-			"id": "342",
+			"id": "346",
 			"label": "Faithful Hound",
 			"levels3d": {
 				"enable": true,
@@ -75866,7 +76689,7 @@
 			}
 		},
 		{
-			"id": "343",
+			"id": "347",
 			"label": "False Life",
 			"levels3d": {
 				"enable": true,
@@ -76089,7 +76912,7 @@
 			}
 		},
 		{
-			"id": "344",
+			"id": "348",
 			"label": "Fast Hands",
 			"levels3d": {
 				"type": "explosion",
@@ -76301,7 +77124,7 @@
 			}
 		},
 		{
-			"id": "345",
+			"id": "349",
 			"label": "Feather Fall",
 			"levels3d": {
 				"enable": true,
@@ -76527,7 +77350,7 @@
 			}
 		},
 		{
-			"id": "346",
+			"id": "350",
 			"label": "Feign Death",
 			"levels3d": {
 				"enable": true,
@@ -76752,7 +77575,7 @@
 			}
 		},
 		{
-			"id": "347",
+			"id": "351",
 			"label": "Find Familiar",
 			"levels3d": {
 				"enable": true,
@@ -76971,7 +77794,7 @@
 			}
 		},
 		{
-			"id": "348",
+			"id": "352",
 			"label": "Find Greater Steed",
 			"levels3d": {
 				"enable": true,
@@ -77190,7 +78013,7 @@
 			}
 		},
 		{
-			"id": "349",
+			"id": "353",
 			"label": "Find Steed",
 			"levels3d": {
 				"enable": true,
@@ -77409,7 +78232,7 @@
 			}
 		},
 		{
-			"id": "350",
+			"id": "354",
 			"label": "Find the Path",
 			"levels3d": {
 				"enable": true,
@@ -77627,7 +78450,7 @@
 			}
 		},
 		{
-			"id": "351",
+			"id": "355",
 			"label": "Find Traps",
 			"levels3d": {
 				"enable": true,
@@ -77847,7 +78670,7 @@
 			}
 		},
 		{
-			"id": "352",
+			"id": "356",
 			"label": "Fire Storm",
 			"levels3d": {
 				"type": "explosion",
@@ -78059,7 +78882,7 @@
 			}
 		},
 		{
-			"id": "353",
+			"id": "357",
 			"label": "Fizban's Platinum Shield",
 			"levels3d": {
 				"type": "explosion",
@@ -78271,7 +79094,7 @@
 			}
 		},
 		{
-			"id": "354",
+			"id": "358",
 			"label": "Flame Arrows",
 			"levels3d": {
 				"enable": true,
@@ -78490,7 +79313,7 @@
 			}
 		},
 		{
-			"id": "355",
+			"id": "359",
 			"label": "Flame Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -78728,230 +79551,7 @@
 			}
 		},
 		{
-			"id": "356",
-			"label": "Flash of Genius",
-			"levels3d": {
-				"enable": true,
-				"type": "magicsphere",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/emberssmall.png",
-					"onCenter": true,
-					"alpha": 1,
-					"color01": "#007517",
-					"color02": "#9b06fe",
-					"rate": 5
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.ui.indicator.green.01.01",
-						"type": "mysteriouslights",
-						"color01": "#dfd007",
-						"color02": "#00fa81",
-						"alpha": 1,
-						"onCenter": true,
-						"rate": 25
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-2.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-2.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "energy",
-					"animation": "dodecahedron",
-					"variant": "rolled",
-					"color": "blue",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Flash of Genius",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "357",
+			"id": "360",
 			"label": "Flesh to Stone",
 			"levels3d": {
 				"type": "castingsign",
@@ -79165,7 +79765,7 @@
 			}
 		},
 		{
-			"id": "358",
+			"id": "361",
 			"label": "Floating Disk",
 			"levels3d": {
 				"enable": true,
@@ -79386,7 +79986,7 @@
 			}
 		},
 		{
-			"id": "359",
+			"id": "362",
 			"label": "Fly",
 			"levels3d": {
 				"enable": true,
@@ -79609,7 +80209,7 @@
 			}
 		},
 		{
-			"id": "360",
+			"id": "363",
 			"label": "Flyby",
 			"levels3d": {
 				"type": "slash",
@@ -79825,7 +80425,7 @@
 			}
 		},
 		{
-			"id": "361",
+			"id": "364",
 			"label": "Font of Inspiration",
 			"levels3d": {
 				"type": "explosion",
@@ -80037,7 +80637,7 @@
 			}
 		},
 		{
-			"id": "362",
+			"id": "365",
 			"label": "Font of Magic",
 			"levels3d": {
 				"type": "explosion",
@@ -80249,7 +80849,7 @@
 			}
 		},
 		{
-			"id": "363",
+			"id": "366",
 			"label": "Forbiddance",
 			"levels3d": {
 				"type": "explosion",
@@ -80461,7 +81061,7 @@
 			}
 		},
 		{
-			"id": "364",
+			"id": "367",
 			"label": "Forcecage",
 			"levels3d": {
 				"type": "explosion",
@@ -80674,7 +81274,7 @@
 			}
 		},
 		{
-			"id": "365",
+			"id": "368",
 			"label": "Foresight",
 			"levels3d": {
 				"enable": true,
@@ -80896,7 +81496,7 @@
 			}
 		},
 		{
-			"id": "366",
+			"id": "369",
 			"label": "Freedom of Movement",
 			"levels3d": {
 				"enable": true,
@@ -81115,7 +81715,7 @@
 			}
 		},
 		{
-			"id": "367",
+			"id": "370",
 			"label": "Friends",
 			"levels3d": {
 				"type": "explosion",
@@ -81327,7 +81927,7 @@
 			}
 		},
 		{
-			"id": "368",
+			"id": "371",
 			"label": "Frightful Presence",
 			"levels3d": {
 				"enable": true,
@@ -81551,7 +82151,7 @@
 			}
 		},
 		{
-			"id": "369",
+			"id": "372",
 			"label": "Frostbite",
 			"levels3d": {
 				"enable": true,
@@ -81611,7 +82211,7 @@
 					"elevation": 1000,
 					"fadeIn": 250,
 					"fadeOut": 500,
-					"isMasked": false,
+					"isMasked": true,
 					"isRadius": false,
 					"isWait": false,
 					"opacity": 0.5,
@@ -81771,12 +82371,12 @@
 				"label": "Frostbite",
 				"menu": "ontoken",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
+				"moduleVersion": "2.1.0",
+				"version": "16867533014171"
 			}
 		},
 		{
-			"id": "370",
+			"id": "373",
 			"label": "Gaseous Form",
 			"levels3d": {
 				"enable": true,
@@ -81999,7 +82599,7 @@
 			}
 		},
 		{
-			"id": "371",
+			"id": "374",
 			"label": "Gate",
 			"levels3d": {
 				"enable": true,
@@ -82221,7 +82821,7 @@
 			}
 		},
 		{
-			"id": "372",
+			"id": "375",
 			"label": "Gaze",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -82436,7 +83036,7 @@
 			}
 		},
 		{
-			"id": "373",
+			"id": "376",
 			"label": "Geas",
 			"levels3d": {
 				"type": "castingsign",
@@ -82652,7 +83252,7 @@
 			}
 		},
 		{
-			"id": "374",
+			"id": "377",
 			"label": "Gentle Repose",
 			"levels3d": {
 				"enable": true,
@@ -82871,7 +83471,7 @@
 			}
 		},
 		{
-			"id": "375",
+			"id": "378",
 			"label": "Giant Insect",
 			"levels3d": {
 				"type": "castingsign",
@@ -83086,7 +83686,7 @@
 			}
 		},
 		{
-			"id": "376",
+			"id": "379",
 			"label": "Glare",
 			"levels3d": {
 				"type": "projectile",
@@ -83305,7 +83905,7 @@
 			}
 		},
 		{
-			"id": "377",
+			"id": "380",
 			"label": "Glibness",
 			"levels3d": {
 				"type": "explosion",
@@ -83517,7 +84117,7 @@
 			}
 		},
 		{
-			"id": "378",
+			"id": "381",
 			"label": "Glorious Defense",
 			"levels3d": {
 				"type": "explosion",
@@ -83729,7 +84329,7 @@
 			}
 		},
 		{
-			"id": "379",
+			"id": "382",
 			"label": "Glyph of Warding",
 			"levels3d": {
 				"enable": true,
@@ -83948,7 +84548,7 @@
 			}
 		},
 		{
-			"id": "380",
+			"id": "383",
 			"label": "Goodberry",
 			"levels3d": {
 				"enable": true,
@@ -84174,7 +84774,7 @@
 			}
 		},
 		{
-			"id": "381",
+			"id": "384",
 			"label": "Gore",
 			"levels3d": {
 				"enable": true,
@@ -84397,7 +84997,7 @@
 			}
 		},
 		{
-			"id": "382",
+			"id": "385",
 			"label": "Grasping Vine",
 			"levels3d": {
 				"type": "castingsign",
@@ -84612,7 +85212,7 @@
 			}
 		},
 		{
-			"id": "383",
+			"id": "386",
 			"label": "Greater Comprehension",
 			"levels3d": {
 				"enable": true,
@@ -84836,7 +85436,7 @@
 			}
 		},
 		{
-			"id": "384",
+			"id": "387",
 			"label": "Greater Invisibility",
 			"levels3d": {
 				"enable": true,
@@ -85083,7 +85683,7 @@
 			}
 		},
 		{
-			"id": "385",
+			"id": "388",
 			"label": "Greater Restoration",
 			"levels3d": {
 				"enable": true,
@@ -85306,7 +85906,7 @@
 			}
 		},
 		{
-			"id": "386",
+			"id": "389",
 			"label": "Green-Flame Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -85547,7 +86147,7 @@
 			}
 		},
 		{
-			"id": "387",
+			"id": "390",
 			"label": "Guardian of Faith",
 			"levels3d": {
 				"type": "castingsign",
@@ -85762,7 +86362,7 @@
 			}
 		},
 		{
-			"id": "388",
+			"id": "391",
 			"label": "Guardian of Nature",
 			"levels3d": {
 				"type": "explosion",
@@ -85974,7 +86574,7 @@
 			}
 		},
 		{
-			"id": "389",
+			"id": "392",
 			"label": "Guards and Wards",
 			"levels3d": {
 				"type": "explosion",
@@ -86186,7 +86786,7 @@
 			}
 		},
 		{
-			"id": "390",
+			"id": "393",
 			"label": "Guidance",
 			"levels3d": {
 				"type": "explosion",
@@ -86398,7 +86998,7 @@
 			}
 		},
 		{
-			"id": "391",
+			"id": "394",
 			"label": "Gust",
 			"levels3d": {
 				"type": "castingsign",
@@ -86620,7 +87220,7 @@
 			}
 		},
 		{
-			"id": "392",
+			"id": "395",
 			"label": "Hail of Thorns",
 			"levels3d": {
 				"enable": true,
@@ -86845,7 +87445,7 @@
 			}
 		},
 		{
-			"id": "393",
+			"id": "396",
 			"label": "Hand of Harm",
 			"levels3d": {
 				"type": "explosion",
@@ -87057,7 +87657,7 @@
 			}
 		},
 		{
-			"id": "394",
+			"id": "397",
 			"label": "Hand of Healing",
 			"levels3d": {
 				"type": "explosion",
@@ -87269,7 +87869,7 @@
 			}
 		},
 		{
-			"id": "395",
+			"id": "398",
 			"label": "Hand of Ultimate Mercy",
 			"levels3d": {
 				"type": "explosion",
@@ -87482,7 +88082,7 @@
 			}
 		},
 		{
-			"id": "396",
+			"id": "399",
 			"label": "Harm",
 			"levels3d": {
 				"enable": true,
@@ -87713,7 +88313,7 @@
 			}
 		},
 		{
-			"id": "397",
+			"id": "400",
 			"label": "Haste",
 			"levels3d": {
 				"enable": true,
@@ -87935,7 +88535,7 @@
 			}
 		},
 		{
-			"id": "398",
+			"id": "401",
 			"label": "Heal-disabled",
 			"levels3d": {
 				"enable": true,
@@ -88170,7 +88770,7 @@
 			}
 		},
 		{
-			"id": "399",
+			"id": "402",
 			"label": "Healing Hands",
 			"levels3d": {
 				"enable": true,
@@ -88394,7 +88994,7 @@
 			}
 		},
 		{
-			"id": "400",
+			"id": "403",
 			"label": "Healing Light",
 			"levels3d": {
 				"type": "explosion",
@@ -88606,7 +89206,7 @@
 			}
 		},
 		{
-			"id": "401",
+			"id": "404",
 			"label": "Healing Surge",
 			"levels3d": {
 				"enable": true,
@@ -88829,7 +89429,7 @@
 			}
 		},
 		{
-			"id": "402",
+			"id": "405",
 			"label": "Healing Touch",
 			"levels3d": {
 				"type": "explosion",
@@ -89036,7 +89636,7 @@
 			}
 		},
 		{
-			"id": "403",
+			"id": "406",
 			"label": "Healing Word",
 			"levels3d": {
 				"enable": true,
@@ -89287,7 +89887,7 @@
 			}
 		},
 		{
-			"id": "404",
+			"id": "407",
 			"label": "Heat Metal",
 			"levels3d": {
 				"enable": true,
@@ -89509,7 +90109,7 @@
 			}
 		},
 		{
-			"id": "405",
+			"id": "408",
 			"label": "Hellish Rebuke",
 			"levels3d": {
 				"enable": true,
@@ -89732,7 +90332,7 @@
 			}
 		},
 		{
-			"id": "406",
+			"id": "409",
 			"label": "Heroes' Feast",
 			"levels3d": {
 				"enable": true,
@@ -89952,7 +90552,7 @@
 			}
 		},
 		{
-			"id": "407",
+			"id": "410",
 			"label": "Heroism",
 			"levels3d": {
 				"enable": true,
@@ -90175,7 +90775,7 @@
 			}
 		},
 		{
-			"id": "408",
+			"id": "411",
 			"label": "Hex",
 			"levels3d": {
 				"enable": true,
@@ -90399,7 +90999,7 @@
 			}
 		},
 		{
-			"id": "409",
+			"id": "412",
 			"label": "Hide in Plain Sight",
 			"levels3d": {
 				"type": "explosion",
@@ -90611,7 +91211,7 @@
 			}
 		},
 		{
-			"id": "410",
+			"id": "413",
 			"label": "Hideous Laughter",
 			"levels3d": {
 				"enable": true,
@@ -90834,7 +91434,7 @@
 			}
 		},
 		{
-			"id": "411",
+			"id": "414",
 			"label": "Hold Monster",
 			"levels3d": {
 				"enable": true,
@@ -91054,7 +91654,7 @@
 			}
 		},
 		{
-			"id": "412",
+			"id": "415",
 			"label": "Hold Person",
 			"levels3d": {
 				"enable": true,
@@ -91274,7 +91874,7 @@
 			}
 		},
 		{
-			"id": "413",
+			"id": "416",
 			"label": "Holy Nimbus",
 			"levels3d": {
 				"type": "explosion",
@@ -91486,7 +92086,7 @@
 			}
 		},
 		{
-			"id": "414",
+			"id": "417",
 			"label": "Holy Weapon",
 			"levels3d": {
 				"type": "explosion",
@@ -91545,7 +92145,7 @@
 					"opacity": 1,
 					"persistent": false,
 					"playbackRate": 1,
-					"playOn": "default",
+					"playOn": "source",
 					"repeat": 1,
 					"repeatDelay": 250,
 					"saturate": 0,
@@ -91693,12 +92293,12 @@
 				"label": "Holy Weapon",
 				"menu": "ontoken",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "415",
+			"id": "418",
 			"label": "Horrifying Visage",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -91913,7 +92513,7 @@
 			}
 		},
 		{
-			"id": "416",
+			"id": "419",
 			"levels3d": {
 				"type": "explosion",
 				"data": {
@@ -92125,7 +92725,7 @@
 			}
 		},
 		{
-			"id": "417",
+			"id": "420",
 			"label": "Hunter's Defense",
 			"levels3d": {
 				"type": "explosion",
@@ -92337,7 +92937,7 @@
 			}
 		},
 		{
-			"id": "418",
+			"id": "421",
 			"label": "Hunter's Mark",
 			"levels3d": {
 				"enable": true,
@@ -92586,7 +93186,7 @@
 			}
 		},
 		{
-			"id": "419",
+			"id": "422",
 			"label": "Hunter's Prey",
 			"levels3d": {
 				"type": "explosion",
@@ -92798,7 +93398,7 @@
 			}
 		},
 		{
-			"id": "420",
+			"id": "423",
 			"label": "Hurl Through Hell",
 			"levels3d": {
 				"type": "explosion",
@@ -93011,7 +93611,7 @@
 			}
 		},
 		{
-			"id": "421",
+			"id": "424",
 			"label": "Identify",
 			"levels3d": {
 				"enable": true,
@@ -93229,7 +93829,7 @@
 			}
 		},
 		{
-			"id": "422",
+			"id": "425",
 			"label": "Illusory Dragon",
 			"levels3d": {
 				"type": "explosion",
@@ -93441,7 +94041,7 @@
 			}
 		},
 		{
-			"id": "423",
+			"id": "426",
 			"label": "Illusory Reality",
 			"levels3d": {
 				"type": "explosion",
@@ -93653,7 +94253,7 @@
 			}
 		},
 		{
-			"id": "424",
+			"id": "427",
 			"label": "Illusory Script",
 			"levels3d": {
 				"enable": true,
@@ -93872,7 +94472,7 @@
 			}
 		},
 		{
-			"id": "425",
+			"id": "428",
 			"label": "Illusory Self",
 			"levels3d": {
 				"enable": true,
@@ -94119,7 +94719,7 @@
 			}
 		},
 		{
-			"id": "426",
+			"id": "429",
 			"label": "Immolation",
 			"levels3d": {
 				"enable": true,
@@ -94343,7 +94943,7 @@
 			}
 		},
 		{
-			"id": "427",
+			"id": "430",
 			"label": "Imprisonment",
 			"levels3d": {
 				"enable": true,
@@ -94562,7 +95162,7 @@
 			}
 		},
 		{
-			"id": "428",
+			"id": "431",
 			"label": "Indomitable",
 			"levels3d": {
 				"type": "explosion",
@@ -94774,7 +95374,7 @@
 			}
 		},
 		{
-			"id": "429",
+			"id": "432",
 			"label": "Infernal Calling",
 			"levels3d": {
 				"enable": true,
@@ -94997,241 +95597,7 @@
 			}
 		},
 		{
-			"id": "430",
-			"label": "Infestation",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
-					"speed": 10,
-					"duration": 2000,
-					"life": 400,
-					"alpha": 1,
-					"onCenter": true,
-					"color01": "#ff9500",
-					"color02": "#beb7b7"
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.butterflies.many.bright_orange",
-						"type": "jb2aexplosionnolight",
-						"speed": 10,
-						"scale": 1,
-						"alpha": 1,
-						"onCenter": true,
-						"color01": "#d2cbcb",
-						"color02": "#dbce0f",
-						"duration": 2500,
-						"life": 400
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": true,
-					"sourceType": "swipe",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "particles",
-					"animation": "dots",
-					"variant": "03",
-					"color": "green",
-					"enableCustom": true,
-					"customPath": "jb2a.butterflies.many.orange"
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 2000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1.2,
-					"zIndex": 1,
-					"tint": true,
-					"tintColor": "#00ff55"
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.butterflies.many.orange"
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1,
-					"playbackRate": 3
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "conjuration",
-					"variant": "runecomplete",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 1000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 0.75,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"tint": true,
-					"tintColor": "#ae00ff"
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.butterflies.many.orange"
-				}
-			},
-			"metaData": {
-				"label": "Infestation",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "431",
+			"id": "433",
 			"label": "Infiltration Expertise",
 			"levels3d": {
 				"type": "explosion",
@@ -95443,7 +95809,7 @@
 			}
 		},
 		{
-			"id": "432",
+			"id": "434",
 			"label": "Inflict Wounds",
 			"levels3d": {
 				"enable": true,
@@ -95667,7 +96033,7 @@
 			}
 		},
 		{
-			"id": "433",
+			"id": "435",
 			"label": "Ink",
 			"levels3d": {
 				"type": "explosion",
@@ -95879,7 +96245,7 @@
 			}
 		},
 		{
-			"id": "434",
+			"id": "436",
 			"label": "Instant Summons",
 			"levels3d": {
 				"enable": true,
@@ -96103,1077 +96469,7 @@
 			}
 		},
 		{
-			"id": "435",
-			"label": "Intellect Fortress",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_07.webp",
-					"color01": "#bb25e4",
-					"color02": "#d982ca",
-					"alpha": 1,
-					"onCenter": true
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "modules/jb2a_patreon/Library/Generic/Impact/PartSideImpactShockwave01_01_Regular_Blue_Thumb.webp",
-						"type": "magicsphere",
-						"alpha": 1,
-						"onCenter": true,
-						"color01": "#c8a3a3",
-						"color02": "#7dcab4",
-						"rate": 5
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-plant-moving-2.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "default",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-plant-moving-2.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "energyfield",
-					"variant": "01",
-					"color": "purple",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Intellect Fortress",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "436",
-			"label": "Investiture of Flame",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "fire",
-					"variant": "03",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "red",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Investiture of Flame",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
 			"id": "437",
-			"label": "Investiture of Ice",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "ice",
-					"variant": "03",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "darkblue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Investiture of Ice",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "438",
-			"label": "Investiture of Stone",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "earth",
-					"variant": "03",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-earth-moving-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Investiture of Stone",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "439",
-			"label": "Investiture of Wind",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "antilifeshell",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.wind_stream.200.white"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-wind-gust-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": true,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "darkgreen",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Investiture of Wind",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "440",
 			"label": "Invisibility",
 			"levels3d": {
 				"enable": true,
@@ -97420,7 +96716,7 @@
 			}
 		},
 		{
-			"id": "441",
+			"id": "438",
 			"label": "Invoke Duplicity",
 			"levels3d": {
 				"type": "explosion",
@@ -97632,219 +96928,7 @@
 			}
 		},
 		{
-			"id": "442",
-			"label": "Invulnerability",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "tokenborder",
-					"animation": "spinning",
-					"variant": "04",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-3.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.25,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "abjuration",
-					"variant": "complete",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Invulnerability",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "443",
+			"id": "439",
 			"label": "Irresistible Dance",
 			"levels3d": {
 				"enable": true,
@@ -98065,7 +97149,7 @@
 			}
 		},
 		{
-			"id": "444",
+			"id": "440",
 			"label": "Jump",
 			"levels3d": {
 				"enable": true,
@@ -98313,7 +97397,7 @@
 			}
 		},
 		{
-			"id": "445",
+			"id": "441",
 			"label": "Kinetic Jaunt",
 			"levels3d": {
 				"type": "explosion",
@@ -98352,7 +97436,7 @@
 				"sound": {
 					"enable": true,
 					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/spell-whoosh-1.mp3",
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/spell-whoosh-2.mp3",
 					"repeat": 1,
 					"repeatDelay": 250,
 					"startTime": 0,
@@ -98372,8 +97456,8 @@
 					"opacity": 1,
 					"persistent": false,
 					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 1,
+					"playOn": "source",
+					"repeat": 2,
 					"repeatDelay": 250,
 					"saturate": 0,
 					"size": 1,
@@ -98520,12 +97604,12 @@
 				"label": "Kinetic Jaunt",
 				"menu": "ontoken",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "446",
+			"id": "442",
 			"label": "Knock",
 			"levels3d": {
 				"enable": true,
@@ -98751,7 +97835,7 @@
 			}
 		},
 		{
-			"id": "447",
+			"id": "443",
 			"label": "Lay on Hands",
 			"levels3d": {
 				"enable": true,
@@ -98975,7 +98059,7 @@
 			}
 		},
 		{
-			"id": "448",
+			"id": "444",
 			"label": "Legend Lore",
 			"levels3d": {
 				"type": "castingsign",
@@ -99189,7 +98273,7 @@
 			}
 		},
 		{
-			"id": "449",
+			"id": "445",
 			"label": "Levitate",
 			"levels3d": {
 				"enable": true,
@@ -99411,7 +98495,7 @@
 			}
 		},
 		{
-			"id": "450",
+			"id": "446",
 			"label": "Light",
 			"levels3d": {
 				"type": "explosion",
@@ -99623,7 +98707,7 @@
 			}
 		},
 		{
-			"id": "451",
+			"id": "447",
 			"label": "Lightning Arrow",
 			"levels3d": {
 				"enable": true,
@@ -99843,7 +98927,7 @@
 			}
 		},
 		{
-			"id": "452",
+			"id": "448",
 			"label": "Locate",
 			"levels3d": {
 				"enable": true,
@@ -100063,7 +99147,7 @@
 			}
 		},
 		{
-			"id": "453",
+			"id": "449",
 			"label": "Locate Creature",
 			"levels3d": {
 				"enable": true,
@@ -100283,7 +99367,7 @@
 			}
 		},
 		{
-			"id": "454",
+			"id": "450",
 			"label": "Longstrider",
 			"levels3d": {
 				"enable": true,
@@ -100536,7 +99620,7 @@
 			}
 		},
 		{
-			"id": "455",
+			"id": "451",
 			"label": "Maelstrom",
 			"levels3d": {
 				"type": "explosion",
@@ -100748,7 +99832,7 @@
 			}
 		},
 		{
-			"id": "456",
+			"id": "452",
 			"label": "Mage Hand",
 			"levels3d": {
 				"type": "explosion",
@@ -100960,7 +100044,7 @@
 			}
 		},
 		{
-			"id": "457",
+			"id": "453",
 			"label": "Magic Aura",
 			"levels3d": {
 				"enable": true,
@@ -101182,7 +100266,7 @@
 			}
 		},
 		{
-			"id": "458",
+			"id": "454",
 			"label": "Magic Jar",
 			"levels3d": {
 				"type": "explosion",
@@ -101395,7 +100479,7 @@
 			}
 		},
 		{
-			"id": "459",
+			"id": "455",
 			"label": "Magic Mouth",
 			"levels3d": {
 				"enable": true,
@@ -101617,7 +100701,7 @@
 			}
 		},
 		{
-			"id": "460",
+			"id": "456",
 			"label": "Magic Weapon",
 			"levels3d": {
 				"enable": true,
@@ -101836,7 +100920,7 @@
 			}
 		},
 		{
-			"id": "461",
+			"id": "457",
 			"label": "Magical Cunning",
 			"levels3d": {
 				"type": "explosion",
@@ -102048,7 +101132,7 @@
 			}
 		},
 		{
-			"id": "462",
+			"id": "458",
 			"label": "Magical Tinkering",
 			"levels3d": {
 				"type": "explosion",
@@ -102260,7 +101344,7 @@
 			}
 		},
 		{
-			"id": "463",
+			"id": "459",
 			"label": "Magnificent Mansion",
 			"levels3d": {
 				"type": "explosion",
@@ -102472,7 +101556,7 @@
 			}
 		},
 		{
-			"id": "464",
+			"id": "460",
 			"label": "Mantle of Inspiration",
 			"levels3d": {
 				"type": "explosion",
@@ -102684,7 +101768,7 @@
 			}
 		},
 		{
-			"id": "465",
+			"id": "461",
 			"label": "Mass Heal",
 			"levels3d": {
 				"enable": true,
@@ -102919,7 +102003,7 @@
 			}
 		},
 		{
-			"id": "466",
+			"id": "462",
 			"label": "Meld into Stone",
 			"levels3d": {
 				"enable": true,
@@ -103145,7 +102229,7 @@
 			}
 		},
 		{
-			"id": "467",
+			"id": "463",
 			"label": "Melf's Minute Meteors",
 			"levels3d": {
 				"type": "explosion",
@@ -103357,7 +102441,7 @@
 			}
 		},
 		{
-			"id": "468",
+			"id": "464",
 			"label": "Mending",
 			"levels3d": {
 				"type": "explosion",
@@ -103569,218 +102653,7 @@
 			}
 		},
 		{
-			"id": "469",
-			"label": "Mental Prison",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "illusion",
-					"variant": "runecomplete",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "chains",
-					"animation": "diamond",
-					"variant": "complete",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 500,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Mental Prison",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "470",
+			"id": "465",
 			"label": "Metamagic",
 			"levels3d": {
 				"enable": true,
@@ -104001,7 +102874,7 @@
 			}
 		},
 		{
-			"id": "471",
+			"id": "466",
 			"label": "Meteor Swarm",
 			"levels3d": {
 				"type": "explosion",
@@ -104214,7 +103087,7 @@
 			}
 		},
 		{
-			"id": "472",
+			"id": "467",
 			"label": "Midnight Tears",
 			"levels3d": {
 				"type": "explosion",
@@ -104426,7 +103299,7 @@
 			}
 		},
 		{
-			"id": "473",
+			"id": "468",
 			"label": "Mighty Fortress",
 			"levels3d": {
 				"type": "explosion",
@@ -104639,7 +103512,7 @@
 			}
 		},
 		{
-			"id": "474",
+			"id": "469",
 			"label": "Mind Blank",
 			"levels3d": {
 				"type": "castingsign",
@@ -104856,7 +103729,7 @@
 			}
 		},
 		{
-			"id": "475",
+			"id": "470",
 			"label": "Mirror Image",
 			"levels3d": {
 				"enable": true,
@@ -105074,7 +103947,7 @@
 			}
 		},
 		{
-			"id": "476",
+			"id": "471",
 			"label": "Mislead",
 			"levels3d": {
 				"type": "castingsign",
@@ -105288,7 +104161,7 @@
 			}
 		},
 		{
-			"id": "477",
+			"id": "472",
 			"label": "Mold Earth",
 			"levels3d": {
 				"enable": true,
@@ -105513,7 +104386,7 @@
 			}
 		},
 		{
-			"id": "478",
+			"id": "473",
 			"label": "Mordenkainen's Sword",
 			"levels3d": {
 				"type": "explosion",
@@ -105725,7 +104598,7 @@
 			}
 		},
 		{
-			"id": "479",
+			"id": "474",
 			"label": "Move Earth",
 			"levels3d": {
 				"type": "explosion",
@@ -105940,7 +104813,7 @@
 			}
 		},
 		{
-			"id": "480",
+			"id": "475",
 			"label": "Natural Recovery",
 			"levels3d": {
 				"type": "explosion",
@@ -106152,7 +105025,7 @@
 			}
 		},
 		{
-			"id": "481",
+			"id": "476",
 			"label": "Net",
 			"levels3d": {
 				"enable": true,
@@ -106377,7 +105250,7 @@
 			}
 		},
 		{
-			"id": "482",
+			"id": "477",
 			"label": "Nondetection",
 			"levels3d": {
 				"enable": true,
@@ -106598,7 +105471,7 @@
 			}
 		},
 		{
-			"id": "483",
+			"id": "478",
 			"label": "Oil of Taggit",
 			"levels3d": {
 				"type": "explosion",
@@ -106810,7 +105683,7 @@
 			}
 		},
 		{
-			"id": "484",
+			"id": "479",
 			"label": "Overchannel",
 			"levels3d": {
 				"type": "explosion",
@@ -107023,7 +105896,7 @@
 			}
 		},
 		{
-			"id": "485",
+			"id": "480",
 			"label": "Pale Tincture",
 			"levels3d": {
 				"type": "explosion",
@@ -107235,7 +106108,7 @@
 			}
 		},
 		{
-			"id": "486",
+			"id": "481",
 			"label": "Passwall",
 			"levels3d": {
 				"enable": true,
@@ -107453,7 +106326,7 @@
 			}
 		},
 		{
-			"id": "487",
+			"id": "482",
 			"label": "Patient Defense",
 			"levels3d": {
 				"type": "explosion",
@@ -107665,7 +106538,7 @@
 			}
 		},
 		{
-			"id": "488",
+			"id": "483",
 			"label": "Perfect Self",
 			"levels3d": {
 				"type": "explosion",
@@ -107877,7 +106750,7 @@
 			}
 		},
 		{
-			"id": "489",
+			"id": "484",
 			"label": "Phantasmal Killer",
 			"levels3d": {
 				"type": "castingsign",
@@ -108091,7 +106964,7 @@
 			}
 		},
 		{
-			"id": "490",
+			"id": "485",
 			"label": "Phantom Steed",
 			"levels3d": {
 				"enable": true,
@@ -108311,7 +107184,7 @@
 			}
 		},
 		{
-			"id": "491",
+			"id": "486",
 			"label": "Planar Ally",
 			"levels3d": {
 				"type": "castingsign",
@@ -108526,7 +107399,7 @@
 			}
 		},
 		{
-			"id": "492",
+			"id": "487",
 			"label": "Plane Shift",
 			"levels3d": {
 				"type": "castingsign",
@@ -108742,7 +107615,7 @@
 			}
 		},
 		{
-			"id": "493",
+			"id": "488",
 			"label": "Plant Growth",
 			"levels3d": {
 				"enable": true,
@@ -108961,7 +107834,7 @@
 			}
 		},
 		{
-			"id": "494",
+			"id": "489",
 			"label": "Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -109173,7 +108046,7 @@
 			}
 		},
 		{
-			"id": "495",
+			"id": "490",
 			"label": "Polymorph",
 			"levels3d": {
 				"type": "castingsign",
@@ -109390,7 +108263,7 @@
 			}
 		},
 		{
-			"id": "496",
+			"id": "491",
 			"label": "Potion of",
 			"levels3d": {
 				"type": "vortex",
@@ -109604,7 +108477,7 @@
 			}
 		},
 		{
-			"id": "497",
+			"id": "492",
 			"label": "Potion of Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -109816,7 +108689,7 @@
 			}
 		},
 		{
-			"id": "498",
+			"id": "493",
 			"label": "Power Word",
 			"levels3d": {
 				"enable": true,
@@ -110034,7 +108907,7 @@
 			}
 		},
 		{
-			"id": "499",
+			"id": "494",
 			"label": "Power Word Fortify",
 			"levels3d": {
 				"enable": true,
@@ -110252,7 +109125,7 @@
 			}
 		},
 		{
-			"id": "500",
+			"id": "495",
 			"label": "Power Word Heal",
 			"levels3d": {
 				"enable": true,
@@ -110473,7 +109346,7 @@
 			}
 		},
 		{
-			"id": "501",
+			"id": "496",
 			"label": "Power Word Kill",
 			"levels3d": {
 				"enable": true,
@@ -110691,7 +109564,7 @@
 			}
 		},
 		{
-			"id": "502",
+			"id": "497",
 			"label": "Power Word Pain",
 			"levels3d": {
 				"enable": true,
@@ -110909,7 +109782,7 @@
 			}
 		},
 		{
-			"id": "503",
+			"id": "498",
 			"label": "Power Word Stun",
 			"levels3d": {
 				"enable": true,
@@ -111127,7 +110000,7 @@
 			}
 		},
 		{
-			"id": "504",
+			"id": "499",
 			"label": "Prayer of Healing",
 			"levels3d": {
 				"enable": true,
@@ -111348,7 +110221,7 @@
 			}
 		},
 		{
-			"id": "505",
+			"id": "500",
 			"label": "Preserve Life",
 			"levels3d": {
 				"type": "explosion",
@@ -111561,7 +110434,7 @@
 			}
 		},
 		{
-			"id": "506",
+			"id": "501",
 			"label": "Prestidigitation",
 			"levels3d": {
 				"type": "explosion",
@@ -111773,7 +110646,7 @@
 			}
 		},
 		{
-			"id": "507",
+			"id": "502",
 			"label": "Primal Companion",
 			"levels3d": {
 				"type": "explosion",
@@ -111985,232 +110858,7 @@
 			}
 		},
 		{
-			"id": "508",
-			"label": "Primal Savagery",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_06.webp",
-					"color01": "#008a17",
-					"color02": "#ff0a0a",
-					"duration": 2500,
-					"life": 400,
-					"onCenter": true,
-					"alpha": 1,
-					"speed": 6
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.claws.400px.bright_green",
-						"type": "jb2aexplosion",
-						"color01": "#cc0000",
-						"color02": "#d40256",
-						"onCenter": true,
-						"speed": 10,
-						"alpha": 1
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-1.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "buff",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-1.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "creature",
-					"animation": "claw",
-					"variant": "01",
-					"color": "green",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Primal Savagery",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "509",
+			"id": "503",
 			"label": "Primeval Awareness",
 			"levels3d": {
 				"type": "explosion",
@@ -112422,218 +111070,7 @@
 			}
 		},
 		{
-			"id": "510",
-			"label": "Primordial Ward",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "eldritchweb",
-					"variant": "01",
-					"color": "darkpurple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "complete",
-					"variant": "01",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 500,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 0.78,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Primordial Ward",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "511",
+			"id": "504",
 			"levels3d": {
 				"type": "explosion",
 				"data": {
@@ -112846,7 +111283,7 @@
 			}
 		},
 		{
-			"id": "512",
+			"id": "505",
 			"label": "Project Image",
 			"levels3d": {
 				"type": "castingsign",
@@ -113061,7 +111498,7 @@
 			}
 		},
 		{
-			"id": "513",
+			"id": "506",
 			"label": "Projected Ward",
 			"levels3d": {
 				"type": "explosion",
@@ -113273,7 +111710,7 @@
 			}
 		},
 		{
-			"id": "514",
+			"id": "507",
 			"label": "Protection from Evil and Good",
 			"levels3d": {
 				"enable": true,
@@ -113490,7 +111927,7 @@
 			}
 		},
 		{
-			"id": "515",
+			"id": "508",
 			"label": "Protection from Poison",
 			"levels3d": {
 				"enable": true,
@@ -113711,7 +112148,7 @@
 			}
 		},
 		{
-			"id": "516",
+			"id": "509",
 			"label": "Purple Worm Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -113923,7 +112360,7 @@
 			}
 		},
 		{
-			"id": "517",
+			"id": "510",
 			"label": "Quickened Healing",
 			"levels3d": {
 				"enable": true,
@@ -114144,7 +112581,7 @@
 			}
 		},
 		{
-			"id": "518",
+			"id": "511",
 			"label": "Radiant Soul",
 			"levels3d": {
 				"type": "explosion",
@@ -114356,7 +112793,7 @@
 			}
 		},
 		{
-			"id": "519",
+			"id": "512",
 			"label": "Rage",
 			"levels3d": {
 				"enable": true,
@@ -114580,7 +113017,7 @@
 			}
 		},
 		{
-			"id": "520",
+			"id": "513",
 			"label": "Raise Dead",
 			"levels3d": {
 				"enable": true,
@@ -114802,7 +113239,7 @@
 			}
 		},
 		{
-			"id": "521",
+			"id": "514",
 			"label": "Raulothim's Psychic Lance",
 			"levels3d": {
 				"type": "explosion",
@@ -115015,7 +113452,7 @@
 			}
 		},
 		{
-			"id": "522",
+			"id": "515",
 			"label": "Regenerate",
 			"levels3d": {
 				"enable": true,
@@ -115235,7 +113672,7 @@
 			}
 		},
 		{
-			"id": "523",
+			"id": "516",
 			"label": "Reincarnate",
 			"levels3d": {
 				"enable": true,
@@ -115457,7 +113894,7 @@
 			}
 		},
 		{
-			"id": "524",
+			"id": "517",
 			"label": "Relentless Endurance",
 			"levels3d": {
 				"type": "explosion",
@@ -115669,7 +114106,7 @@
 			}
 		},
 		{
-			"id": "525",
+			"id": "518",
 			"label": "Remove Curse",
 			"levels3d": {
 				"enable": true,
@@ -115891,7 +114328,7 @@
 			}
 		},
 		{
-			"id": "526",
+			"id": "519",
 			"label": "Resilient Sphere",
 			"levels3d": {
 				"type": "castingsign",
@@ -116106,7 +114543,7 @@
 			}
 		},
 		{
-			"id": "527",
+			"id": "520",
 			"label": "Restoration",
 			"levels3d": {
 				"enable": true,
@@ -116329,7 +114766,7 @@
 			}
 		},
 		{
-			"id": "528",
+			"id": "521",
 			"label": "Resurrection",
 			"levels3d": {
 				"enable": true,
@@ -116553,7 +114990,7 @@
 			}
 		},
 		{
-			"id": "529",
+			"id": "522",
 			"label": "Revelation in Flesh",
 			"levels3d": {
 				"type": "explosion",
@@ -116765,7 +115202,7 @@
 			}
 		},
 		{
-			"id": "530",
+			"id": "523",
 			"label": "Revivify",
 			"levels3d": {
 				"enable": true,
@@ -116987,7 +115424,7 @@
 			}
 		},
 		{
-			"id": "531",
+			"id": "524",
 			"label": "Rope Trick",
 			"levels3d": {
 				"enable": true,
@@ -117209,7 +115646,7 @@
 			}
 		},
 		{
-			"id": "532",
+			"id": "525",
 			"label": "Sacred Flame",
 			"levels3d": {
 				"type": "explosion",
@@ -117422,7 +115859,7 @@
 			}
 		},
 		{
-			"id": "533",
+			"id": "526",
 			"label": "Sacred Weapon",
 			"levels3d": {
 				"type": "explosion",
@@ -117634,7 +116071,7 @@
 			}
 		},
 		{
-			"id": "534",
+			"id": "527",
 			"label": "Sanctuary",
 			"levels3d": {
 				"enable": true,
@@ -117854,7 +116291,7 @@
 			}
 		},
 		{
-			"id": "535",
+			"id": "528",
 			"label": "Sapping Sting",
 			"levels3d": {
 				"enable": true,
@@ -118076,7 +116513,7 @@
 			}
 		},
 		{
-			"id": "536",
+			"id": "529",
 			"label": "Scatter",
 			"levels3d": {
 				"enable": true,
@@ -118298,7 +116735,7 @@
 			}
 		},
 		{
-			"id": "537",
+			"id": "530",
 			"label": "Scrying",
 			"levels3d": {
 				"type": "castingsign",
@@ -118516,7 +116953,7 @@
 			}
 		},
 		{
-			"id": "538",
+			"id": "531",
 			"label": "Sear Undead",
 			"levels3d": {
 				"type": "explosion",
@@ -118728,7 +117165,7 @@
 			}
 		},
 		{
-			"id": "539",
+			"id": "532",
 			"label": "Searing Vengeance",
 			"levels3d": {
 				"type": "explosion",
@@ -118941,7 +117378,7 @@
 			}
 		},
 		{
-			"id": "540",
+			"id": "533",
 			"label": "Second Wind",
 			"levels3d": {
 				"enable": true,
@@ -119164,7 +117601,7 @@
 			}
 		},
 		{
-			"id": "541",
+			"id": "534",
 			"label": "Secret Chest",
 			"levels3d": {
 				"enable": true,
@@ -119387,7 +117824,7 @@
 			}
 		},
 		{
-			"id": "542",
+			"id": "535",
 			"label": "See Invisibility",
 			"levels3d": {
 				"enable": true,
@@ -119611,7 +118048,7 @@
 			}
 		},
 		{
-			"id": "543",
+			"id": "536",
 			"label": "Seeming",
 			"levels3d": {
 				"type": "castingsign",
@@ -119828,7 +118265,7 @@
 			}
 		},
 		{
-			"id": "544",
+			"id": "537",
 			"label": "Sending",
 			"levels3d": {
 				"enable": true,
@@ -120047,7 +118484,7 @@
 			}
 		},
 		{
-			"id": "545",
+			"id": "538",
 			"label": "Sequester",
 			"levels3d": {
 				"type": "explosion",
@@ -120260,7 +118697,7 @@
 			}
 		},
 		{
-			"id": "546",
+			"id": "539",
 			"label": "Serpent Venom",
 			"levels3d": {
 				"type": "explosion",
@@ -120472,7 +118909,7 @@
 			}
 		},
 		{
-			"id": "547",
+			"id": "540",
 			"label": "Shadow Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -120712,7 +119149,7 @@
 			}
 		},
 		{
-			"id": "548",
+			"id": "541",
 			"label": "Shadow of Moil",
 			"levels3d": {
 				"enable": true,
@@ -120934,7 +119371,7 @@
 			}
 		},
 		{
-			"id": "549",
+			"id": "542",
 			"label": "Shape Water",
 			"levels3d": {
 				"enable": true,
@@ -121156,7 +119593,7 @@
 			}
 		},
 		{
-			"id": "550",
+			"id": "543",
 			"label": "Shapechange",
 			"levels3d": {
 				"type": "castingsign",
@@ -121373,7 +119810,7 @@
 			}
 		},
 		{
-			"id": "551",
+			"id": "544",
 			"label": "Shillelagh",
 			"levels3d": {
 				"type": "explosion",
@@ -121585,7 +120022,7 @@
 			}
 		},
 		{
-			"id": "552",
+			"id": "545",
 			"label": "Silvery Barbs",
 			"levels3d": {
 				"type": "explosion",
@@ -121797,7 +120234,7 @@
 			}
 		},
 		{
-			"id": "553",
+			"id": "546",
 			"label": "Simulacrum",
 			"levels3d": {
 				"type": "explosion",
@@ -122009,7 +120446,7 @@
 			}
 		},
 		{
-			"id": "554",
+			"id": "547",
 			"label": "Skill Empowerment",
 			"levels3d": {
 				"enable": true,
@@ -122255,7 +120692,7 @@
 			}
 		},
 		{
-			"id": "555",
+			"id": "548",
 			"label": "Skywrite",
 			"levels3d": {
 				"type": "explosion",
@@ -122314,7 +120751,7 @@
 					"opacity": 1,
 					"persistent": false,
 					"playbackRate": 1,
-					"playOn": "default",
+					"playOn": "source",
 					"repeat": 1,
 					"repeatDelay": 250,
 					"saturate": 0,
@@ -122462,12 +120899,12 @@
 				"label": "Skywrite",
 				"menu": "ontoken",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "556",
+			"id": "549",
 			"label": "Slow Fall",
 			"levels3d": {
 				"type": "explosion",
@@ -122679,7 +121116,7 @@
 			}
 		},
 		{
-			"id": "557",
+			"id": "550",
 			"label": "Smite",
 			"levels3d": {
 				"enable": true,
@@ -122904,7 +121341,7 @@
 			}
 		},
 		{
-			"id": "558",
+			"id": "551",
 			"label": "Snare",
 			"levels3d": {
 				"enable": true,
@@ -123124,7 +121561,7 @@
 			}
 		},
 		{
-			"id": "559",
+			"id": "552",
 			"label": "Sneak Attack",
 			"levels3d": {
 				"type": "slash",
@@ -123339,7 +121776,7 @@
 			}
 		},
 		{
-			"id": "560",
+			"id": "553",
 			"label": "Song of Rest",
 			"levels3d": {
 				"type": "explosion",
@@ -123574,7 +122011,7 @@
 			}
 		},
 		{
-			"id": "561",
+			"id": "554",
 			"label": "Sorcerous Restoration",
 			"levels3d": {
 				"type": "explosion",
@@ -123786,7 +122223,7 @@
 			}
 		},
 		{
-			"id": "562",
+			"id": "555",
 			"label": "Sorcery Incarnate",
 			"levels3d": {
 				"type": "explosion",
@@ -123998,7 +122435,7 @@
 			}
 		},
 		{
-			"id": "563",
+			"id": "556",
 			"label": "Sorcery Points",
 			"levels3d": {
 				"type": "explosion",
@@ -124210,7 +122647,7 @@
 			}
 		},
 		{
-			"id": "564",
+			"id": "557",
 			"label": "Soul of Artifice",
 			"levels3d": {
 				"type": "explosion",
@@ -124422,7 +122859,7 @@
 			}
 		},
 		{
-			"id": "565",
+			"id": "558",
 			"label": "Spare the Dying",
 			"levels3d": {
 				"type": "explosion",
@@ -124634,7 +123071,7 @@
 			}
 		},
 		{
-			"id": "566",
+			"id": "559",
 			"label": "Speak with Animals",
 			"levels3d": {
 				"enable": true,
@@ -124854,7 +123291,7 @@
 			}
 		},
 		{
-			"id": "567",
+			"id": "560",
 			"label": "Speak with Dead",
 			"levels3d": {
 				"enable": true,
@@ -125071,7 +123508,7 @@
 			}
 		},
 		{
-			"id": "568",
+			"id": "561",
 			"label": "Speak with Plants",
 			"levels3d": {
 				"enable": true,
@@ -125290,7 +123727,7 @@
 			}
 		},
 		{
-			"id": "569",
+			"id": "562",
 			"label": "Spectral Fangs",
 			"levels3d": {
 				"type": "slash",
@@ -125505,7 +123942,7 @@
 			}
 		},
 		{
-			"id": "570",
+			"id": "563",
 			"label": "Spell Thief",
 			"levels3d": {
 				"type": "slash",
@@ -125720,7 +124157,7 @@
 			}
 		},
 		{
-			"id": "571",
+			"id": "564",
 			"label": "Spider Climb",
 			"levels3d": {
 				"enable": true,
@@ -125954,232 +124391,7 @@
 			}
 		},
 		{
-			"id": "572",
-			"label": "Spirit Shroud",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_13.webp",
-					"color01": "#07ed0f",
-					"color02": "#0b988e",
-					"speed": 7,
-					"alpha": 1,
-					"onCenter": true
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "modules/levels-3d-preview/assets/particles/emberssmall.png",
-						"type": "magicsphere",
-						"color01": "#05f50d",
-						"color02": "#388505",
-						"onCenter": true,
-						"alpha": 1,
-						"rate": 5,
-						"speed": 6,
-						"scale": 2
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-1.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 3.5,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-1.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "spiritguardians",
-					"variant": "noring",
-					"color": "lightgreen",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Spirit Shroud",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "573",
+			"id": "565",
 			"label": "Spiritual Weapon",
 			"levels3d": {
 				"enable": true,
@@ -126400,7 +124612,7 @@
 			}
 		},
 		{
-			"id": "574",
+			"id": "566",
 			"label": "Spore",
 			"levels3d": {
 				"type": "fairy",
@@ -126616,7 +124828,7 @@
 			}
 		},
 		{
-			"id": "575",
+			"id": "567",
 			"label": "Stalker's Flurry",
 			"levels3d": {
 				"type": "explosion",
@@ -126828,7 +125040,7 @@
 			}
 		},
 		{
-			"id": "576",
+			"id": "568",
 			"label": "Step of the Wind",
 			"levels3d": {
 				"type": "explosion",
@@ -127040,7 +125252,7 @@
 			}
 		},
 		{
-			"id": "577",
+			"id": "569",
 			"label": "Stillness of Mind",
 			"levels3d": {
 				"enable": true,
@@ -127288,7 +125500,7 @@
 			}
 		},
 		{
-			"id": "578",
+			"id": "570",
 			"label": "Stone Shape",
 			"levels3d": {
 				"type": "castingsign",
@@ -127503,7 +125715,7 @@
 			}
 		},
 		{
-			"id": "579",
+			"id": "571",
 			"label": "Storm of Vengeance",
 			"levels3d": {
 				"type": "explosion",
@@ -127716,7 +125928,7 @@
 			}
 		},
 		{
-			"id": "580",
+			"id": "572",
 			"label": "Stroke of Luck",
 			"levels3d": {
 				"type": "explosion",
@@ -127928,7 +126140,7 @@
 			}
 		},
 		{
-			"id": "581",
+			"id": "573",
 			"label": "Suggestion",
 			"levels3d": {
 				"enable": true,
@@ -128155,7 +126367,7 @@
 			}
 		},
 		{
-			"id": "582",
+			"id": "574",
 			"label": "Summon Aberration",
 			"levels3d": {
 				"enable": true,
@@ -128378,7 +126590,7 @@
 			}
 		},
 		{
-			"id": "583",
+			"id": "575",
 			"label": "Summon Beast",
 			"levels3d": {
 				"enable": true,
@@ -128601,7 +126813,7 @@
 			}
 		},
 		{
-			"id": "584",
+			"id": "576",
 			"label": "Summon Celestial",
 			"levels3d": {
 				"enable": true,
@@ -128824,7 +127036,7 @@
 			}
 		},
 		{
-			"id": "585",
+			"id": "577",
 			"label": "Summon Construct",
 			"levels3d": {
 				"enable": true,
@@ -129047,7 +127259,7 @@
 			}
 		},
 		{
-			"id": "586",
+			"id": "578",
 			"label": "Summon Draconic Spirit",
 			"levels3d": {
 				"enable": true,
@@ -129270,7 +127482,7 @@
 			}
 		},
 		{
-			"id": "587",
+			"id": "579",
 			"label": "Summon Dragon",
 			"levels3d": {
 				"enable": true,
@@ -129493,7 +127705,7 @@
 			}
 		},
 		{
-			"id": "588",
+			"id": "580",
 			"label": "Summon Elemental",
 			"levels3d": {
 				"enable": true,
@@ -129716,7 +127928,7 @@
 			}
 		},
 		{
-			"id": "589",
+			"id": "581",
 			"label": "Summon Fey",
 			"levels3d": {
 				"enable": true,
@@ -129939,7 +128151,7 @@
 			}
 		},
 		{
-			"id": "590",
+			"id": "582",
 			"label": "Summon Fiend",
 			"levels3d": {
 				"enable": true,
@@ -130162,7 +128374,7 @@
 			}
 		},
 		{
-			"id": "591",
+			"id": "583",
 			"label": "Summon Greater Demon",
 			"levels3d": {
 				"enable": true,
@@ -130385,7 +128597,7 @@
 			}
 		},
 		{
-			"id": "592",
+			"id": "584",
 			"label": "Summon Lesser Demon",
 			"levels3d": {
 				"enable": true,
@@ -130608,7 +128820,7 @@
 			}
 		},
 		{
-			"id": "593",
+			"id": "585",
 			"label": "Summon Shadowspawn",
 			"levels3d": {
 				"enable": true,
@@ -130831,7 +129043,7 @@
 			}
 		},
 		{
-			"id": "594",
+			"id": "586",
 			"label": "Summon Undead",
 			"levels3d": {
 				"enable": true,
@@ -131054,7 +129266,7 @@
 			}
 		},
 		{
-			"id": "595",
+			"id": "587",
 			"label": "Supreme Sneak",
 			"levels3d": {
 				"type": "explosion",
@@ -131268,7 +129480,7 @@
 			}
 		},
 		{
-			"id": "596",
+			"id": "588",
 			"label": "Swallow",
 			"levels3d": {
 				"type": "jb2aexplosionnolight",
@@ -131482,7 +129694,7 @@
 			}
 		},
 		{
-			"id": "597",
+			"id": "589",
 			"label": "Swift Quiver",
 			"levels3d": {
 				"type": "castingsign",
@@ -131696,7 +129908,7 @@
 			}
 		},
 		{
-			"id": "598",
+			"id": "590",
 			"label": "Sword Burst",
 			"levels3d": {
 				"type": "explosion",
@@ -131908,7 +130120,7 @@
 			}
 		},
 		{
-			"id": "599",
+			"id": "591",
 			"label": "Symbol",
 			"levels3d": {
 				"type": "castingsign",
@@ -132123,7 +130335,7 @@
 			}
 		},
 		{
-			"id": "600",
+			"id": "592",
 			"label": "Tactical Mind",
 			"levels3d": {
 				"type": "explosion",
@@ -132335,7 +130547,7 @@
 			}
 		},
 		{
-			"id": "601",
+			"id": "593",
 			"label": "Tactical Shift",
 			"levels3d": {
 				"type": "explosion",
@@ -132547,7 +130759,7 @@
 			}
 		},
 		{
-			"id": "602",
+			"id": "594",
 			"label": "Talon",
 			"levels3d": {
 				"enable": true,
@@ -132765,7 +130977,7 @@
 			}
 		},
 		{
-			"id": "603",
+			"id": "595",
 			"label": "Tamed Surge",
 			"levels3d": {
 				"type": "explosion",
@@ -132977,7 +131189,7 @@
 			}
 		},
 		{
-			"id": "604",
+			"id": "596",
 			"label": "Tasha's Otherworldly Guise",
 			"levels3d": {
 				"enable": true,
@@ -133052,7 +131264,7 @@
 				"sound": {
 					"delay": 0,
 					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/spell-whoosh-9.mp3",
 					"startTime": 0,
 					"volume": 0.75,
 					"repeat": 1,
@@ -133195,12 +131407,12 @@
 				"label": "Tasha's Otherworldly Guise",
 				"menu": "ontoken",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
+				"moduleVersion": "2.1.0",
+				"version": "16867533014171"
 			}
 		},
 		{
-			"id": "605",
+			"id": "597",
 			"label": "Telekinesis",
 			"levels3d": {
 				"type": "castingsign",
@@ -133415,7 +131627,7 @@
 			}
 		},
 		{
-			"id": "606",
+			"id": "598",
 			"label": "Telekinetic",
 			"levels3d": {
 				"type": "explosion",
@@ -133627,7 +131839,7 @@
 			}
 		},
 		{
-			"id": "607",
+			"id": "599",
 			"label": "Telepathy",
 			"levels3d": {
 				"type": "explosion",
@@ -133842,7 +132054,7 @@
 			}
 		},
 		{
-			"id": "608",
+			"id": "600",
 			"label": "Teleportation Circle",
 			"levels3d": {
 				"type": "explosion",
@@ -134055,7 +132267,7 @@
 			}
 		},
 		{
-			"id": "609",
+			"id": "601",
 			"label": "Temple of the Gods",
 			"levels3d": {
 				"type": "explosion",
@@ -134267,7 +132479,7 @@
 			}
 		},
 		{
-			"id": "610",
+			"id": "602",
 			"label": "Tenser's Transformation",
 			"levels3d": {
 				"type": "explosion",
@@ -134479,7 +132691,7 @@
 			}
 		},
 		{
-			"id": "611",
+			"id": "603",
 			"label": "Tentacle",
 			"levels3d": {
 				"enable": true,
@@ -134701,7 +132913,7 @@
 			}
 		},
 		{
-			"id": "612",
+			"id": "604",
 			"label": "Thaumaturgy",
 			"levels3d": {
 				"type": "explosion",
@@ -134914,7 +133126,7 @@
 			}
 		},
 		{
-			"id": "613",
+			"id": "605",
 			"label": "Thorn Whip",
 			"levels3d": {
 				"type": "explosion",
@@ -135129,7 +133341,7 @@
 			}
 		},
 		{
-			"id": "614",
+			"id": "606",
 			"label": "Tidal Wave",
 			"levels3d": {
 				"type": "explosion",
@@ -135341,7 +133553,7 @@
 			}
 		},
 		{
-			"id": "615",
+			"id": "607",
 			"label": "Tides of Chaos",
 			"levels3d": {
 				"type": "explosion",
@@ -135553,7 +133765,7 @@
 			}
 		},
 		{
-			"id": "616",
+			"id": "608",
 			"label": "Time Stop",
 			"levels3d": {
 				"enable": true,
@@ -135772,7 +133984,7 @@
 			}
 		},
 		{
-			"id": "617",
+			"id": "609",
 			"label": "Tiny Servant",
 			"levels3d": {
 				"enable": true,
@@ -135989,7 +134201,7 @@
 			}
 		},
 		{
-			"id": "618",
+			"id": "610",
 			"label": "Tireless",
 			"levels3d": {
 				"type": "explosion",
@@ -136201,7 +134413,7 @@
 			}
 		},
 		{
-			"id": "619",
+			"id": "611",
 			"label": "Toll the Dead",
 			"levels3d": {
 				"type": "explosion",
@@ -136413,7 +134625,7 @@
 			}
 		},
 		{
-			"id": "620",
+			"id": "612",
 			"label": "Tongue",
 			"levels3d": {
 				"type": "slash",
@@ -136629,7 +134841,7 @@
 			}
 		},
 		{
-			"id": "621",
+			"id": "613",
 			"label": "Tongues",
 			"levels3d": {
 				"enable": true,
@@ -136850,7 +135062,7 @@
 			}
 		},
 		{
-			"id": "622",
+			"id": "614",
 			"label": "Torpor",
 			"levels3d": {
 				"type": "explosion",
@@ -137062,7 +135274,7 @@
 			}
 		},
 		{
-			"id": "623",
+			"id": "615",
 			"label": "Touch",
 			"levels3d": {
 				"type": "slash",
@@ -137277,7 +135489,7 @@
 			}
 		},
 		{
-			"id": "624",
+			"id": "616",
 			"label": "Transport via Plants",
 			"levels3d": {
 				"type": "explosion",
@@ -137489,7 +135701,7 @@
 			}
 		},
 		{
-			"id": "625",
+			"id": "617",
 			"label": "Tree Stride",
 			"levels3d": {
 				"type": "castingsign",
@@ -137704,7 +135916,7 @@
 			}
 		},
 		{
-			"id": "626",
+			"id": "618",
 			"label": "True Seeing",
 			"levels3d": {
 				"enable": true,
@@ -137928,7 +136140,7 @@
 			}
 		},
 		{
-			"id": "627",
+			"id": "619",
 			"label": "True Strike",
 			"levels3d": {
 				"type": "explosion",
@@ -138140,7 +136352,7 @@
 			}
 		},
 		{
-			"id": "628",
+			"id": "620",
 			"label": "Truth Serum",
 			"levels3d": {
 				"type": "explosion",
@@ -138352,7 +136564,7 @@
 			}
 		},
 		{
-			"id": "629",
+			"id": "621",
 			"label": "Tsunami",
 			"levels3d": {
 				"type": "explosion",
@@ -138565,7 +136777,7 @@
 			}
 		},
 		{
-			"id": "630",
+			"id": "622",
 			"label": "Uncanny Dodge",
 			"levels3d": {
 				"type": "explosion",
@@ -138777,7 +136989,7 @@
 			}
 		},
 		{
-			"id": "631",
+			"id": "623",
 			"label": "Uncanny Metabolism",
 			"levels3d": {
 				"type": "explosion",
@@ -138989,7 +137201,7 @@
 			}
 		},
 		{
-			"id": "632",
+			"id": "624",
 			"label": "Undying Sentinel",
 			"levels3d": {
 				"type": "explosion",
@@ -139201,7 +137413,7 @@
 			}
 		},
 		{
-			"id": "633",
+			"id": "625",
 			"label": "Unseen Servant",
 			"levels3d": {
 				"enable": true,
@@ -139418,7 +137630,7 @@
 			}
 		},
 		{
-			"id": "634",
+			"id": "626",
 			"label": "Unsettling Words",
 			"levels3d": {
 				"type": "castingsign",
@@ -139650,7 +137862,7 @@
 			}
 		},
 		{
-			"id": "635",
+			"id": "627",
 			"label": "Vanish",
 			"levels3d": {
 				"type": "explosion",
@@ -139862,7 +138074,7 @@
 			}
 		},
 		{
-			"id": "636",
+			"id": "628",
 			"label": "Vicious Mockery",
 			"levels3d": {
 				"type": "explosion",
@@ -140074,7 +138286,7 @@
 			}
 		},
 		{
-			"id": "637",
+			"id": "629",
 			"label": "Vigilant Blessing",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -140283,7 +138495,219 @@
 			}
 		},
 		{
-			"id": "638",
+			"id": "630",
+			"label": "Vitality of the Tree",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "generichealing",
+					"variant": "01",
+					"color": "green",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "plants",
+					"animation": "circle",
+					"variant": "complete",
+					"color": "greenyellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Vitality of the Tree",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.0.0",
+				"version": 1740566308510
+			}
+		},
+		{
+			"id": "631",
 			"label": "Vortex Warp",
 			"levels3d": {
 				"enable": true,
@@ -140505,7 +138929,7 @@
 			}
 		},
 		{
-			"id": "639",
+			"id": "632",
 			"label": "Vow of Enmity",
 			"levels3d": {
 				"type": "explosion",
@@ -140717,7 +139141,7 @@
 			}
 		},
 		{
-			"id": "640",
+			"id": "633",
 			"label": "War Bond",
 			"levels3d": {
 				"type": "explosion",
@@ -140929,7 +139353,7 @@
 			}
 		},
 		{
-			"id": "641",
+			"id": "634",
 			"label": "Warding Bond",
 			"levels3d": {
 				"enable": true,
@@ -141150,7 +139574,7 @@
 			}
 		},
 		{
-			"id": "642",
+			"id": "635",
 			"label": "Warding Flare",
 			"levels3d": {
 				"type": "explosion",
@@ -141362,7 +139786,7 @@
 			}
 		},
 		{
-			"id": "643",
+			"id": "636",
 			"label": "Warrior of the Gods",
 			"levels3d": {
 				"type": "explosion",
@@ -141575,7 +139999,7 @@
 			}
 		},
 		{
-			"id": "644",
+			"id": "637",
 			"label": "Water Breathing",
 			"levels3d": {
 				"enable": true,
@@ -141799,7 +140223,7 @@
 			}
 		},
 		{
-			"id": "645",
+			"id": "638",
 			"label": "Water Walk",
 			"levels3d": {
 				"enable": true,
@@ -142024,7 +140448,7 @@
 			}
 		},
 		{
-			"id": "646",
+			"id": "639",
 			"label": "Wholeness of Body",
 			"levels3d": {
 				"type": "explosion",
@@ -142236,7 +140660,7 @@
 			}
 		},
 		{
-			"id": "647",
+			"id": "640",
 			"label": "Wild Resurgence",
 			"levels3d": {
 				"enable": true,
@@ -142454,7 +140878,7 @@
 			}
 		},
 		{
-			"id": "648",
+			"id": "641",
 			"label": "Wild Shape",
 			"levels3d": {
 				"enable": true,
@@ -142671,7 +141095,7 @@
 			}
 		},
 		{
-			"id": "649",
+			"id": "642",
 			"label": "Wind Walk",
 			"levels3d": {
 				"type": "castingsign",
@@ -142887,7 +141311,7 @@
 			}
 		},
 		{
-			"id": "650",
+			"id": "643",
 			"label": "Wish",
 			"levels3d": {
 				"type": "castingsign",
@@ -143103,7 +141527,7 @@
 			}
 		},
 		{
-			"id": "651",
+			"id": "644",
 			"label": "Withering Touch",
 			"levels3d": {
 				"type": "castingsign",
@@ -143320,7 +141744,7 @@
 			}
 		},
 		{
-			"id": "652",
+			"id": "645",
 			"label": "Word of Radiance",
 			"levels3d": {
 				"enable": true,
@@ -143548,7 +141972,7 @@
 			}
 		},
 		{
-			"id": "653",
+			"id": "646",
 			"label": "Word of Recall",
 			"levels3d": {
 				"type": "explosion",
@@ -143760,7 +142184,7 @@
 			}
 		},
 		{
-			"id": "654",
+			"id": "647",
 			"label": "Wyvern Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -143972,7 +142396,7 @@
 			}
 		},
 		{
-			"id": "655",
+			"id": "648",
 			"label": "Zealous Presence",
 			"levels3d": {
 				"type": "explosion",
@@ -144185,7 +142609,7 @@
 			}
 		},
 		{
-			"id": "656",
+			"id": "649",
 			"label": "Zephyr Strike",
 			"levels3d": {
 				"enable": true,
@@ -144405,11 +142829,4570 @@
 				"moduleVersion": "2.0.0",
 				"version": 1686753301417
 			}
+		},
+		{
+			"id": "650",
+			"label": "Absorb Elements",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_attack.01.multicolored01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.25,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Elements",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "651",
+			"label": "Arcane Armor",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "complete",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.magic_signs.rune.02.complete"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Arcane Armor",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "652",
+			"label": "Arcane Jolt",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "energystrand",
+					"variant": "01",
+					"color": "blueorange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Arcane Jolt",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "653",
+			"label": "Armor Model",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "complete",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.magic_signs.rune.02.complete"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Armor Model",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "654",
+			"label": "Cause Fear",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_13.webp",
+					"color01": "#220070",
+					"color02": "#af76d5",
+					"alpha": 1,
+					"duration": 2500,
+					"life": 400
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.toll_the_dead.purple.skull_smoke",
+						"type": "mysteriouslights",
+						"color01": "#4c00ff",
+						"color02": "#ba9fd5",
+						"onCenter": true,
+						"rate": 15,
+						"alpha": 1,
+						"duration": 2200
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": true,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "ui",
+					"variant": "horror",
+					"color": "darkteal",
+					"enableCustom": true,
+					"customPath": "jb2a.condition.curse.01.011.green"
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-2.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Cause Fear",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "655",
+			"label": "Create Magen",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 500,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_generic.slashing.two_handed"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/slashing-blood-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Create Magen",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "656",
+			"label": "Defensive Field",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "complete",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-barrier-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"saturation": -1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Defensive Field",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "657",
+			"label": "Eldritch Cannon",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.hammer.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 600,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Eldritch Cannon",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "658",
+			"label": "Elemental Bane",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_attack.01.multicolored01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Elemental Bane",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "659",
+			"label": "Encode Thoughts",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_12.webp",
+					"color01": "#da98ec",
+					"color02": "#0023d1",
+					"duration": 1500,
+					"onCenter": true,
+					"alpha": 1
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.magic_signs.rune.enchantment.complete.purple",
+						"type": "magicsphere",
+						"color01": "#bfedf3",
+						"color02": "#ff00f7",
+						"onCenter": true,
+						"rate": 5,
+						"alpha": 1,
+						"scale": 2,
+						"gravity": 1,
+						"duration": 3500,
+						"life": 1000
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "shake",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"playbackRate": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "enchantment",
+					"variant": "runecomplete",
+					"color": "pink",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_strands.02.marker.bluepurple"
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Encode Thoughts",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "660",
+			"label": "Flash of Genius",
+			"levels3d": {
+				"enable": true,
+				"type": "magicsphere",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/emberssmall.png",
+					"onCenter": true,
+					"alpha": 1,
+					"color01": "#007517",
+					"color02": "#9b06fe",
+					"rate": 5
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.ui.indicator.green.01.01",
+						"type": "mysteriouslights",
+						"color01": "#dfd007",
+						"color02": "#00fa81",
+						"alpha": 1,
+						"onCenter": true,
+						"rate": 25
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-2.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 800,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": false,
+					"saturation": -1,
+					"contrast": 0.75,
+					"tintColor": "#ffffff"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-1.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "energy",
+					"animation": "dodecahedron",
+					"variant": "rolled",
+					"color": "blue",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 2500,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 0.5,
+					"zIndex": 1,
+					"tint": false,
+					"tintColor": ""
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-3.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "icons/svg/light.svg"
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Flash of Genius",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "661",
+			"label": "Gift of Gab",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "outpulse",
+					"variant": "01",
+					"color": "purplepink",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Bardic-Inspiration.ogg",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Gift of Gab",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "662",
+			"label": "Incite Greed",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.ioun_stones.01.purple.absorption"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 800,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 3500,
+					"saturate": 0,
+					"size": 0.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "light",
+					"variant": "complete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0.75,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 3,
+					"tint": true,
+					"tintColor": "#a382e7",
+					"zIndex": 1,
+					"saturation": -1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Incite Greed",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "663",
+			"label": "Infestation",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
+					"speed": 10,
+					"duration": 2000,
+					"life": 400,
+					"alpha": 1,
+					"onCenter": true,
+					"color01": "#ff9500",
+					"color02": "#beb7b7"
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.butterflies.many.bright_orange",
+						"type": "jb2aexplosionnolight",
+						"speed": 10,
+						"scale": 1,
+						"alpha": 1,
+						"onCenter": true,
+						"color01": "#d2cbcb",
+						"color02": "#dbce0f",
+						"duration": 2500,
+						"life": 400
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": true,
+					"sourceType": "swipe",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "dots",
+					"variant": "03",
+					"color": "green",
+					"enableCustom": true,
+					"customPath": "jb2a.butterflies.many.orange"
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 2000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1.2,
+					"zIndex": 1,
+					"tint": true,
+					"tintColor": "#00ff55"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.butterflies.many.orange"
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1,
+					"playbackRate": 3
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "conjuration",
+					"variant": "runecomplete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 0.75,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"tintColor": "#ae00ff"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.butterflies.many.orange"
+				}
+			},
+			"metaData": {
+				"label": "Infestation",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "664",
+			"label": "Mass Polymorph",
+			"levels3d": {
+				"type": "castingsign",
+				"data": {
+					"color01": "#b2ff24",
+					"color02": "#f94b01",
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_06.webp",
+					"autoSize": true,
+					"alpha": 1,
+					"onCenter": true
+				},
+				"sound": {
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-growl-1.mp3"
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"color01": "#d4ff00",
+						"color02": "#2570e9",
+						"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_06.webp",
+						"autoSize": true,
+						"type": "explosion",
+						"alpha": 1,
+						"onCenter": true,
+						"rate": 25,
+						"duration": 1000
+					}
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				},
+				"enable": true
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "standard",
+					"variant": "02",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-growl-1.mp3",
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 7,
+					"repeatDelay": 1400,
+					"size": 1.25,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "darkyellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-long-2.mp3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 2,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Mass Polymorph",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "665",
+			"label": "Mental Prison",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "illusion",
+					"variant": "runecomplete",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-7.mp3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "chains",
+					"animation": "diamond",
+					"variant": "complete",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 500,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Mental Prison",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "666",
+			"label": "Motivational Speech",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "bardicinspiration",
+					"variant": "inspire",
+					"color": "purplepink",
+					"enableCustom": true,
+					"customPath": "jb2a.music_notations.treble_clef.purple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": -1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "bardicinspiration",
+					"variant": "inspire",
+					"color": "purplepink",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hellish-Rebuke.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Motivational Speech",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "667",
+			"label": "Repair",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.hammer.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 600,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Repair",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "668",
+			"label": "Spirit of Death",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
+					"color01": "#ff00a2",
+					"color02": "#2bff00",
+					"alpha": 1,
+					"onCenter": true
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
+						"type": "holy",
+						"color01": "#6c15ef",
+						"color02": "#60745d",
+						"alpha": 1,
+						"onCenter": false,
+						"speed": 15,
+						"rate": 26
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-short-5.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-2.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "necromancy",
+					"variant": "complete",
+					"color": "green",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Spirit of Death",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "669",
+			"label": "Steel Defender",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.hammer.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 600,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Steel Defender",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "670",
+			"label": "Warp Sense",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_04.webp",
+					"alpha": 1,
+					"color01": "#00aaff",
+					"color02": "#a8f5f0"
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.magic_signs.circle.01.divination",
+						"type": "jb2aexplosion",
+						"onCenter": true,
+						"rate": 5,
+						"life": 700,
+						"alpha": 1,
+						"scale": 1
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-5.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-5.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "divination",
+					"variant": "01",
+					"color": "lightblue",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Warp Sense",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
 		}
 	],
 	"templatefx": [
 		{
-			"id": "657",
+			"id": "671",
 			"label": "Abi-Dalzim's Horrid Wilting",
 			"macro": {
 				"enable": false,
@@ -144429,7 +147412,7 @@
 				"sound": {
 					"enable": true,
 					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-1.mp3",
 					"repeat": 1,
 					"repeatDelay": 250,
 					"startTime": 0,
@@ -144601,7 +147584,7 @@
 			}
 		},
 		{
-			"id": "658",
+			"id": "672",
 			"label": "Acid Breath",
 			"macro": {
 				"enable": false,
@@ -144625,7 +147608,7 @@
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -144775,12 +147758,12 @@
 				"label": "Acid Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "659",
+			"id": "673",
 			"label": "Acid Splash",
 			"macro": {
 				"enable": false,
@@ -144804,7 +147787,7 @@
 					"repeatDelay": 250,
 					"startTime": 750,
 					"volume": 0.75,
-					"file": "psfx.cantrips.acid-splash.v1"
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Acid/acid-bubbling-2.mp3"
 				},
 				"options": {
 					"contrast": 0,
@@ -144970,7 +147953,7 @@
 			}
 		},
 		{
-			"id": "660",
+			"id": "674",
 			"label": "Aganazzar's Scorcher",
 			"macro": {
 				"enable": false,
@@ -145146,7 +148129,7 @@
 			}
 		},
 		{
-			"id": "661",
+			"id": "675",
 			"label": "Alarm",
 			"macro": {
 				"enable": false,
@@ -145336,7 +148319,7 @@
 			}
 		},
 		{
-			"id": "662",
+			"id": "676",
 			"label": "Antipathy/Sympathy",
 			"macro": {
 				"enable": false,
@@ -145525,7 +148508,7 @@
 			}
 		},
 		{
-			"id": "663",
+			"id": "677",
 			"label": "Arms of Hadar",
 			"macro": {
 				"enable": false,
@@ -145715,7 +148698,7 @@
 			}
 		},
 		{
-			"id": "664",
+			"id": "678",
 			"label": "Ball Bearings",
 			"macro": {
 				"enable": false,
@@ -145905,7 +148888,7 @@
 			}
 		},
 		{
-			"id": "665",
+			"id": "679",
 			"label": "Black Tentacles",
 			"macro": {
 				"enable": false,
@@ -146081,7 +149064,7 @@
 			}
 		},
 		{
-			"id": "666",
+			"id": "680",
 			"label": "Blade Barrier",
 			"macro": {
 				"enable": false,
@@ -146272,7 +149255,7 @@
 			}
 		},
 		{
-			"id": "667",
+			"id": "681",
 			"label": "Bones of the Earth",
 			"macro": {
 				"enable": false,
@@ -146462,7 +149445,7 @@
 			}
 		},
 		{
-			"id": "668",
+			"id": "682",
 			"label": "Burning Hands",
 			"macro": {
 				"enable": false,
@@ -146638,7 +149621,7 @@
 			}
 		},
 		{
-			"id": "669",
+			"id": "683",
 			"label": "Call Lightning",
 			"macro": {
 				"enable": false,
@@ -146814,7 +149797,7 @@
 			}
 		},
 		{
-			"id": "670",
+			"id": "684",
 			"label": "Calm Emotions",
 			"macro": {
 				"enable": false,
@@ -146990,7 +149973,7 @@
 			}
 		},
 		{
-			"id": "671",
+			"id": "685",
 			"label": "Caustic Brew",
 			"macro": {
 				"enable": false,
@@ -147008,7 +149991,7 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 0,
 					"rotate": 0,
@@ -147016,9 +149999,9 @@
 					"zIndex": 1
 				},
 				"sound": {
-					"delay": 0,
+					"delay": 500,
 					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Poison/poison-nova-1.mp3",
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Acid/acid-bubbling-2.mp3",
 					"startTime": 0,
 					"volume": 0.75,
 					"repeat": 1,
@@ -147161,12 +150144,12 @@
 				"label": "Caustic Brew",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
+				"moduleVersion": "2.1.0",
+				"version": "16867533014171"
 			}
 		},
 		{
-			"id": "672",
+			"id": "686",
 			"label": "Circle of Death",
 			"macro": {
 				"enable": false,
@@ -147209,7 +150192,7 @@
 					"rotate": 0,
 					"scale": "1",
 					"zIndex": 1,
-					"aboveTemplate": true,
+					"aboveTemplate": false,
 					"tint": true,
 					"tintColor": "#38b238",
 					"saturation": -1,
@@ -147340,12 +150323,12 @@
 				"label": "Circle of Death",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "673",
+			"id": "687",
 			"label": "Cloud of Daggers",
 			"macro": {
 				"enable": false,
@@ -147521,7 +150504,7 @@
 			}
 		},
 		{
-			"id": "674",
+			"id": "688",
 			"label": "Cloudkill",
 			"macro": {
 				"enable": false,
@@ -147695,7 +150678,7 @@
 			}
 		},
 		{
-			"id": "675",
+			"id": "689",
 			"label": "Cold Breath",
 			"macro": {
 				"enable": false,
@@ -147713,13 +150696,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -147869,12 +150852,12 @@
 				"label": "Cold Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "676",
+			"id": "690",
 			"label": "Color Spray",
 			"macro": {
 				"enable": false,
@@ -148050,7 +151033,7 @@
 			}
 		},
 		{
-			"id": "677",
+			"id": "691",
 			"label": "Cone of Cold",
 			"macro": {
 				"enable": false,
@@ -148226,7 +151209,7 @@
 			}
 		},
 		{
-			"id": "678",
+			"id": "692",
 			"label": "Confusion",
 			"macro": {
 				"enable": false,
@@ -148263,7 +151246,7 @@
 					"persistent": false,
 					"persistType": "sequencerground",
 					"playbackRate": 1,
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 250,
 					"rotate": 0,
@@ -148395,12 +151378,12 @@
 				"label": "Confusion",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "679",
+			"id": "693",
 			"label": "Conjure Celestial",
 			"macro": {
 				"enable": false,
@@ -148590,7 +151573,7 @@
 			}
 		},
 		{
-			"id": "680",
+			"id": "694",
 			"label": "Conjure Volley",
 			"macro": {
 				"enable": false,
@@ -148782,7 +151765,7 @@
 			}
 		},
 		{
-			"id": "681",
+			"id": "695",
 			"label": "Control",
 			"macro": {
 				"enable": false,
@@ -148958,197 +151941,7 @@
 			}
 		},
 		{
-			"id": "682",
-			"label": "Control Flames",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "calllightning",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.flames.01.orange"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-flamethrower-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0.5,
-					"occlusionMode": "3",
-					"opacity": 1,
-					"persistent": true,
-					"persistType": "attachtemplate",
-					"playbackRate": 1,
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"rotate": 0,
-					"saturate": 0,
-					"scale": "2.5",
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Control Flames",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1725493831639
-			}
-		},
-		{
-			"id": "683",
+			"id": "696",
 			"label": "Control Water",
 			"macro": {
 				"enable": false,
@@ -149339,7 +152132,7 @@
 			}
 		},
 		{
-			"id": "684",
+			"id": "697",
 			"label": "Control Weather",
 			"macro": {
 				"enable": false,
@@ -149515,7 +152308,7 @@
 			}
 		},
 		{
-			"id": "685",
+			"id": "698",
 			"label": "Control Winds",
 			"macro": {
 				"enable": false,
@@ -149705,7 +152498,7 @@
 			}
 		},
 		{
-			"id": "686",
+			"id": "699",
 			"label": "Create Bonfire",
 			"macro": {
 				"enable": false,
@@ -149725,7 +152518,7 @@
 				"sound": {
 					"enable": true,
 					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-blast-binaural-*",
+					"file": "psfx.ambient.firesources.fireplace.002",
 					"repeat": 1,
 					"repeatDelay": 250,
 					"startTime": 0,
@@ -149890,12 +152683,12 @@
 				"label": "Create Bonfire",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "687",
+			"id": "700",
 			"label": "Create or Destroy Water",
 			"macro": {
 				"enable": false,
@@ -150071,7 +152864,7 @@
 			}
 		},
 		{
-			"id": "688",
+			"id": "701",
 			"label": "Creation",
 			"macro": {
 				"enable": false,
@@ -150114,7 +152907,7 @@
 					"rotate": 0,
 					"scale": "1.5",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				}
 			},
 			"secondary": {
@@ -150241,12 +153034,12 @@
 				"label": "Creation",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "689",
+			"id": "702",
 			"label": "Darkness",
 			"macro": {
 				"enable": false,
@@ -150422,7 +153215,7 @@
 			}
 		},
 		{
-			"id": "690",
+			"id": "703",
 			"label": "Dawn",
 			"macro": {
 				"enable": false,
@@ -150598,7 +153391,7 @@
 			}
 		},
 		{
-			"id": "691",
+			"id": "704",
 			"label": "Daylight",
 			"macro": {
 				"enable": false,
@@ -150776,7 +153569,7 @@
 			}
 		},
 		{
-			"id": "692",
+			"id": "705",
 			"label": "Destructive Wave",
 			"macro": {
 				"enable": false,
@@ -150952,7 +153745,7 @@
 			}
 		},
 		{
-			"id": "693",
+			"id": "706",
 			"label": "Draconic Transformation",
 			"macro": {
 				"enable": false,
@@ -151142,7 +153935,7 @@
 			}
 		},
 		{
-			"id": "694",
+			"id": "707",
 			"label": "Dragon's Breath",
 			"macro": {
 				"enable": false,
@@ -151332,7 +154125,7 @@
 			}
 		},
 		{
-			"id": "695",
+			"id": "708",
 			"label": "Dust Devil",
 			"macro": {
 				"enable": false,
@@ -151522,7 +154315,7 @@
 			}
 		},
 		{
-			"id": "696",
+			"id": "709",
 			"label": "Earthquake",
 			"macro": {
 				"enable": false,
@@ -151699,7 +154492,7 @@
 			}
 		},
 		{
-			"id": "697",
+			"id": "710",
 			"label": "Elemental Burst",
 			"macro": {
 				"enable": false,
@@ -151889,7 +154682,7 @@
 			}
 		},
 		{
-			"id": "698",
+			"id": "711",
 			"label": "Elementalism",
 			"macro": {
 				"enable": false,
@@ -152079,7 +154872,7 @@
 			}
 		},
 		{
-			"id": "699",
+			"id": "712",
 			"label": "Entangle",
 			"macro": {
 				"enable": false,
@@ -152255,7 +155048,7 @@
 			}
 		},
 		{
-			"id": "700",
+			"id": "713",
 			"label": "Erupting Earth",
 			"macro": {
 				"enable": false,
@@ -152445,7 +155238,7 @@
 			}
 		},
 		{
-			"id": "701",
+			"id": "714",
 			"label": "Fabricate",
 			"macro": {
 				"enable": false,
@@ -152635,7 +155428,7 @@
 			}
 		},
 		{
-			"id": "702",
+			"id": "715",
 			"label": "Faerie Fire",
 			"macro": {
 				"enable": false,
@@ -152825,7 +155618,7 @@
 			}
 		},
 		{
-			"id": "703",
+			"id": "716",
 			"label": "Fear",
 			"macro": {
 				"enable": false,
@@ -153003,7 +155796,7 @@
 			}
 		},
 		{
-			"id": "704",
+			"id": "717",
 			"label": "Fire Breath",
 			"macro": {
 				"enable": false,
@@ -153021,13 +155814,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -153177,12 +155970,12 @@
 				"label": "Fire Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "705",
+			"id": "718",
 			"label": "Fire Storm",
 			"macro": {
 				"enable": false,
@@ -153356,7 +156149,7 @@
 			}
 		},
 		{
-			"id": "706",
+			"id": "719",
 			"label": "Flame Strike",
 			"macro": {
 				"enable": false,
@@ -153374,7 +156167,7 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "attachtemplate",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 0,
 					"rotate": 0,
@@ -153527,12 +156320,12 @@
 				"label": "Flame Strike",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "707",
+			"id": "720",
 			"label": "Flaming Sphere",
 			"macro": {
 				"enable": false,
@@ -153708,7 +156501,7 @@
 			}
 		},
 		{
-			"id": "708",
+			"id": "721",
 			"label": "Fog Cloud",
 			"macro": {
 				"enable": false,
@@ -153884,7 +156677,7 @@
 			}
 		},
 		{
-			"id": "709",
+			"id": "722",
 			"label": "Forcecage",
 			"macro": {
 				"enable": false,
@@ -154074,7 +156867,7 @@
 			}
 		},
 		{
-			"id": "710",
+			"id": "723",
 			"label": "Globe of Invulnerability",
 			"macro": {
 				"enable": false,
@@ -154251,7 +157044,7 @@
 			}
 		},
 		{
-			"id": "711",
+			"id": "724",
 			"label": "Grease",
 			"macro": {
 				"enable": false,
@@ -154428,7 +157221,7 @@
 			}
 		},
 		{
-			"id": "712",
+			"id": "725",
 			"label": "Gust of Wind",
 			"macro": {
 				"enable": false,
@@ -154604,7 +157397,7 @@
 			}
 		},
 		{
-			"id": "713",
+			"id": "726",
 			"label": "Hail of Thorns",
 			"macro": {
 				"enable": false,
@@ -154793,7 +157586,7 @@
 			}
 		},
 		{
-			"id": "714",
+			"id": "727",
 			"label": "Hallow",
 			"macro": {
 				"enable": false,
@@ -154836,7 +157629,7 @@
 					"rotate": 0,
 					"scale": "1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				}
 			},
 			"secondary": {
@@ -154965,12 +157758,12 @@
 				"label": "Hallow",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "715",
+			"id": "728",
 			"label": "Hallucinatory Terrain",
 			"macro": {
 				"enable": false,
@@ -155013,7 +157806,7 @@
 					"rotate": 0,
 					"scale": "1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				}
 			},
 			"secondary": {
@@ -155140,12 +157933,12 @@
 				"label": "Hallucinatory Terrain",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "716",
+			"id": "729",
 			"label": "Healing Spirit",
 			"macro": {
 				"enable": false,
@@ -155322,7 +158115,7 @@
 			}
 		},
 		{
-			"id": "717",
+			"id": "730",
 			"label": "Heroes' Feast",
 			"macro": {
 				"enable": false,
@@ -155512,7 +158305,7 @@
 			}
 		},
 		{
-			"id": "718",
+			"id": "731",
 			"label": "Hunger of Hadar",
 			"macro": {
 				"enable": false,
@@ -155688,7 +158481,7 @@
 			}
 		},
 		{
-			"id": "719",
+			"id": "732",
 			"label": "Hypnotic Pattern",
 			"macro": {
 				"enable": false,
@@ -155867,7 +158660,7 @@
 			}
 		},
 		{
-			"id": "720",
+			"id": "733",
 			"label": "Ice Knife",
 			"macro": {
 				"enable": false,
@@ -156057,7 +158850,7 @@
 			}
 		},
 		{
-			"id": "721",
+			"id": "734",
 			"label": "Ice Storm",
 			"macro": {
 				"enable": false,
@@ -156233,7 +159026,7 @@
 			}
 		},
 		{
-			"id": "722",
+			"id": "735",
 			"label": "Image",
 			"macro": {
 				"enable": false,
@@ -156409,7 +159202,7 @@
 			}
 		},
 		{
-			"id": "723",
+			"id": "736",
 			"label": "Incendiary Cloud",
 			"macro": {
 				"enable": false,
@@ -156585,7 +159378,7 @@
 			}
 		},
 		{
-			"id": "724",
+			"id": "737",
 			"label": "Insect Plague",
 			"macro": {
 				"enable": false,
@@ -156760,7 +159553,7 @@
 			}
 		},
 		{
-			"id": "725",
+			"id": "738",
 			"label": "Investiture of Flame",
 			"macro": {
 				"enable": false,
@@ -156950,7 +159743,7 @@
 			}
 		},
 		{
-			"id": "726",
+			"id": "739",
 			"label": "Investiture of Ice",
 			"macro": {
 				"enable": false,
@@ -157140,7 +159933,7 @@
 			}
 		},
 		{
-			"id": "727",
+			"id": "740",
 			"label": "Investiture of Stone",
 			"macro": {
 				"enable": false,
@@ -157330,7 +160123,7 @@
 			}
 		},
 		{
-			"id": "728",
+			"id": "741",
 			"label": "Investiture of Wind",
 			"macro": {
 				"enable": false,
@@ -157520,7 +160313,7 @@
 			}
 		},
 		{
-			"id": "729",
+			"id": "742",
 			"label": "Land's Aid",
 			"macro": {
 				"enable": false,
@@ -157710,7 +160503,7 @@
 			}
 		},
 		{
-			"id": "730",
+			"id": "743",
 			"label": "Lightning Bolt",
 			"macro": {
 				"enable": false,
@@ -157734,7 +160527,7 @@
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 0,
@@ -157882,12 +160675,12 @@
 				"label": "Lightning Bolt",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "731",
+			"id": "744",
 			"label": "Lightning Breath",
 			"macro": {
 				"enable": false,
@@ -157905,13 +160698,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -158061,12 +160854,12 @@
 				"label": "Lightning Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "732",
+			"id": "745",
 			"label": "Magic Circle",
 			"macro": {
 				"enable": false,
@@ -158242,7 +161035,7 @@
 			}
 		},
 		{
-			"id": "733",
+			"id": "746",
 			"label": "Mass Cure Wounds",
 			"macro": {
 				"enable": false,
@@ -158433,7 +161226,7 @@
 			}
 		},
 		{
-			"id": "734",
+			"id": "747",
 			"label": "Maximilian's Earthen Grasp",
 			"macro": {
 				"enable": false,
@@ -158623,7 +161416,7 @@
 			}
 		},
 		{
-			"id": "735",
+			"id": "748",
 			"label": "Meteor Swarm",
 			"macro": {
 				"enable": false,
@@ -158813,7 +161606,7 @@
 			}
 		},
 		{
-			"id": "736",
+			"id": "749",
 			"label": "Mind Blast",
 			"macro": {
 				"enable": false,
@@ -158850,13 +161643,13 @@
 					"persistent": false,
 					"persistType": "sequencerground",
 					"playbackRate": 1.3,
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 250,
 					"rotate": 0,
 					"scale": "1.3",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				}
 			},
 			"secondary": {
@@ -158983,12 +161776,12 @@
 				"label": "Mind Blast",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "737",
+			"id": "750",
 			"label": "Minor Illusion",
 			"macro": {
 				"enable": false,
@@ -159178,7 +161971,7 @@
 			}
 		},
 		{
-			"id": "738",
+			"id": "751",
 			"label": "Mirage Arcane",
 			"macro": {
 				"enable": false,
@@ -159353,7 +162146,7 @@
 			}
 		},
 		{
-			"id": "739",
+			"id": "752",
 			"label": "Misty Escape",
 			"macro": {
 				"enable": false,
@@ -159543,7 +162336,7 @@
 			}
 		},
 		{
-			"id": "740",
+			"id": "753",
 			"label": "Mold Earth",
 			"macro": {
 				"enable": false,
@@ -159581,7 +162374,7 @@
 					"persistent": false,
 					"persistType": "sequencerground",
 					"playbackRate": 1,
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 250,
 					"rotate": 0,
@@ -159728,12 +162521,12 @@
 				"label": "Mold Earth",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1725493831639
+				"moduleVersion": "2.1.0",
+				"version": "17254938316391"
 			}
 		},
 		{
-			"id": "741",
+			"id": "754",
 			"label": "Moonbeam",
 			"macro": {
 				"enable": false,
@@ -159909,7 +162702,7 @@
 			}
 		},
 		{
-			"id": "742",
+			"id": "755",
 			"label": "Move Earth",
 			"macro": {
 				"enable": false,
@@ -160084,7 +162877,7 @@
 			}
 		},
 		{
-			"id": "743",
+			"id": "756",
 			"label": "Nathair's Mischief",
 			"macro": {
 				"enable": false,
@@ -160274,7 +163067,7 @@
 			}
 		},
 		{
-			"id": "744",
+			"id": "757",
 			"label": "Paralyzing Breath",
 			"macro": {
 				"enable": false,
@@ -160292,13 +163085,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -160447,12 +163240,12 @@
 				"label": "Paralyzing Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "745",
+			"id": "758",
 			"label": "Phantasmal Force",
 			"macro": {
 				"enable": false,
@@ -160628,7 +163421,7 @@
 			}
 		},
 		{
-			"id": "746",
+			"id": "759",
 			"label": "Plant Growth",
 			"macro": {
 				"enable": false,
@@ -160819,7 +163612,7 @@
 			}
 		},
 		{
-			"id": "747",
+			"id": "760",
 			"label": "Poison Breath",
 			"macro": {
 				"enable": false,
@@ -160837,13 +163630,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -160992,12 +163785,12 @@
 				"label": "Poison Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "748",
+			"id": "761",
 			"label": "Prismatic Spray",
 			"macro": {
 				"enable": false,
@@ -161034,7 +163827,7 @@
 					"persistent": false,
 					"persistType": "sequencerground",
 					"playbackRate": 1,
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 250,
 					"rotate": 0,
@@ -161167,12 +163960,12 @@
 				"label": "Prismatic Spray",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "749",
+			"id": "762",
 			"label": "Prismatic Wall",
 			"macro": {
 				"enable": false,
@@ -161220,7 +164013,7 @@
 					"tintColor": "#FFFFFF",
 					"zIndex": 1,
 					"saturation": 1,
-					"aboveTemplate": true,
+					"aboveTemplate": false,
 					"anchor": "0.37,0.13"
 				}
 			},
@@ -161360,12 +164153,12 @@
 				"label": "Prismatic Wall",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "750",
+			"id": "763",
 			"label": "Private Sanctum",
 			"macro": {
 				"enable": false,
@@ -161555,7 +164348,7 @@
 			}
 		},
 		{
-			"id": "751",
+			"id": "764",
 			"label": "Programmed Illusion",
 			"macro": {
 				"enable": false,
@@ -161730,7 +164523,7 @@
 			}
 		},
 		{
-			"id": "752",
+			"id": "765",
 			"label": "Purify Food and Drink",
 			"macro": {
 				"enable": false,
@@ -161906,7 +164699,7 @@
 			}
 		},
 		{
-			"id": "753",
+			"id": "766",
 			"label": "Pyrotechnics",
 			"macro": {
 				"enable": false,
@@ -162096,7 +164889,7 @@
 			}
 		},
 		{
-			"id": "754",
+			"id": "767",
 			"label": "Radiance of the Dawn",
 			"macro": {
 				"enable": false,
@@ -162286,7 +165079,7 @@
 			}
 		},
 		{
-			"id": "755",
+			"id": "768",
 			"label": "Repulsion Breath",
 			"macro": {
 				"enable": false,
@@ -162304,13 +165097,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -162459,12 +165252,12 @@
 				"label": "Repulsion Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "756",
+			"id": "769",
 			"label": "Reverse Gravity",
 			"macro": {
 				"enable": false,
@@ -162654,7 +165447,7 @@
 			}
 		},
 		{
-			"id": "757",
+			"id": "770",
 			"label": "Rime's Binding Ice",
 			"macro": {
 				"enable": false,
@@ -162672,7 +165465,7 @@
 					"opacity": 0.75,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
@@ -162830,7 +165623,7 @@
 			}
 		},
 		{
-			"id": "758",
+			"id": "771",
 			"label": "Shape Water",
 			"macro": {
 				"enable": false,
@@ -163020,7 +165813,7 @@
 			}
 		},
 		{
-			"id": "759",
+			"id": "772",
 			"label": "Shatter",
 			"macro": {
 				"enable": false,
@@ -163196,7 +165989,7 @@
 			}
 		},
 		{
-			"id": "760",
+			"id": "773",
 			"label": "Sickening Radiance",
 			"macro": {
 				"enable": false,
@@ -163372,7 +166165,7 @@
 			}
 		},
 		{
-			"id": "761",
+			"id": "774",
 			"label": "Silence",
 			"macro": {
 				"enable": false,
@@ -163549,7 +166342,7 @@
 			}
 		},
 		{
-			"id": "762",
+			"id": "775",
 			"label": "Sleet Storm",
 			"macro": {
 				"enable": false,
@@ -163725,7 +166518,7 @@
 			}
 		},
 		{
-			"id": "763",
+			"id": "776",
 			"label": "Slow",
 			"macro": {
 				"enable": false,
@@ -163900,7 +166693,7 @@
 			}
 		},
 		{
-			"id": "764",
+			"id": "777",
 			"label": "Slowing Breath",
 			"macro": {
 				"enable": false,
@@ -163918,13 +166711,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -164073,12 +166866,12 @@
 				"label": "Slowing Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "765",
+			"id": "778",
 			"label": "Spike Growth",
 			"macro": {
 				"enable": false,
@@ -164255,7 +167048,7 @@
 			}
 		},
 		{
-			"id": "766",
+			"id": "779",
 			"label": "Spiritual Weapon",
 			"macro": {
 				"enable": false,
@@ -164456,7 +167249,7 @@
 			}
 		},
 		{
-			"id": "767",
+			"id": "780",
 			"label": "Stinking Cloud",
 			"macro": {
 				"enable": false,
@@ -164632,7 +167425,7 @@
 			}
 		},
 		{
-			"id": "768",
+			"id": "781",
 			"label": "Storm of Radiance",
 			"macro": {
 				"enable": false,
@@ -164823,7 +167616,7 @@
 			}
 		},
 		{
-			"id": "769",
+			"id": "782",
 			"label": "Storm of Vengeance",
 			"macro": {
 				"enable": false,
@@ -165012,7 +167805,7 @@
 			}
 		},
 		{
-			"id": "770",
+			"id": "783",
 			"label": "Storm Sphere",
 			"macro": {
 				"enable": false,
@@ -165188,7 +167981,7 @@
 			}
 		},
 		{
-			"id": "771",
+			"id": "784",
 			"label": "Sunbeam",
 			"macro": {
 				"enable": false,
@@ -165231,7 +168024,7 @@
 					"rotate": 0,
 					"scale": "1.5",
 					"zIndex": 1,
-					"aboveTemplate": true,
+					"aboveTemplate": false,
 					"anchor": "0.15,0.5",
 					"tint": true,
 					"tintColor": "#ffff00",
@@ -165363,12 +168156,12 @@
 				"label": "Sunbeam",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "772",
+			"id": "785",
 			"label": "Sunburst",
 			"macro": {
 				"enable": false,
@@ -165386,7 +168179,7 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 0,
 					"rotate": 0,
@@ -165540,12 +168333,12 @@
 				"label": "Sunburst",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "773",
+			"id": "786",
 			"label": "Sword Burst",
 			"macro": {
 				"enable": false,
@@ -165735,7 +168528,7 @@
 			}
 		},
 		{
-			"id": "774",
+			"id": "787",
 			"label": "Symbol",
 			"macro": {
 				"enable": false,
@@ -165925,7 +168718,7 @@
 			}
 		},
 		{
-			"id": "775",
+			"id": "788",
 			"label": "Synaptic Static",
 			"macro": {
 				"enable": false,
@@ -165943,7 +168736,7 @@
 					"opacity": 0.75,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
@@ -166096,12 +168889,12 @@
 				"label": "Synaptic Static",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "776",
+			"id": "789",
 			"label": "Teleportation Circle",
 			"macro": {
 				"enable": false,
@@ -166276,7 +169069,7 @@
 			}
 		},
 		{
-			"id": "777",
+			"id": "790",
 			"label": "Tidal Wave",
 			"macro": {
 				"enable": false,
@@ -166467,7 +169260,7 @@
 			}
 		},
 		{
-			"id": "778",
+			"id": "791",
 			"label": "Tiny Hut",
 			"macro": {
 				"enable": false,
@@ -166645,7 +169438,7 @@
 			}
 		},
 		{
-			"id": "779",
+			"id": "792",
 			"label": "Transmute Rock",
 			"macro": {
 				"enable": false,
@@ -166836,7 +169629,7 @@
 			}
 		},
 		{
-			"id": "780",
+			"id": "793",
 			"label": "Tsunami",
 			"macro": {
 				"enable": false,
@@ -167027,7 +169820,7 @@
 			}
 		},
 		{
-			"id": "781",
+			"id": "794",
 			"label": "Wall of Fire",
 			"macro": {
 				"enable": false,
@@ -167205,7 +169998,7 @@
 			}
 		},
 		{
-			"id": "782",
+			"id": "795",
 			"label": "Wall of Force",
 			"macro": {
 				"enable": false,
@@ -167396,7 +170189,7 @@
 			}
 		},
 		{
-			"id": "783",
+			"id": "796",
 			"label": "Wall of Ice",
 			"macro": {
 				"enable": false,
@@ -167586,7 +170379,7 @@
 			}
 		},
 		{
-			"id": "784",
+			"id": "797",
 			"label": "Wall of Light",
 			"macro": {
 				"enable": false,
@@ -167634,7 +170427,7 @@
 					"tintColor": "#FFFFFF",
 					"zIndex": 1,
 					"saturation": 1,
-					"aboveTemplate": true,
+					"aboveTemplate": false,
 					"anchor": "0.37,0.13"
 				}
 			},
@@ -167774,12 +170567,12 @@
 				"label": "Wall of Light",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "785",
+			"id": "798",
 			"label": "Wall of Sand",
 			"macro": {
 				"enable": false,
@@ -167969,7 +170762,7 @@
 			}
 		},
 		{
-			"id": "786",
+			"id": "799",
 			"label": "Wall of Stone",
 			"macro": {
 				"enable": false,
@@ -168159,7 +170952,7 @@
 			}
 		},
 		{
-			"id": "787",
+			"id": "800",
 			"label": "Wall of Thorns",
 			"macro": {
 				"enable": false,
@@ -168349,7 +171142,7 @@
 			}
 		},
 		{
-			"id": "788",
+			"id": "801",
 			"label": "Wall of Water",
 			"macro": {
 				"enable": false,
@@ -168539,7 +171332,7 @@
 			}
 		},
 		{
-			"id": "789",
+			"id": "802",
 			"label": "Warding Wind",
 			"macro": {
 				"enable": false,
@@ -168729,7 +171522,7 @@
 			}
 		},
 		{
-			"id": "790",
+			"id": "803",
 			"label": "Warping Implosion",
 			"macro": {
 				"enable": false,
@@ -168919,7 +171712,7 @@
 			}
 		},
 		{
-			"id": "791",
+			"id": "804",
 			"label": "Watery Sphere",
 			"macro": {
 				"enable": false,
@@ -169109,7 +171902,7 @@
 			}
 		},
 		{
-			"id": "792",
+			"id": "805",
 			"label": "Weakening Breath",
 			"macro": {
 				"enable": false,
@@ -169127,13 +171920,13 @@
 					"opacity": 1,
 					"persistent": false,
 					"persistType": "sequencerground",
-					"removeTemplate": true,
+					"removeTemplate": false,
 					"repeat": 1,
 					"repeatDelay": 500,
 					"rotate": 0,
 					"scale": "1, 1",
 					"zIndex": 1,
-					"aboveTemplate": true
+					"aboveTemplate": false
 				},
 				"sound": {
 					"delay": 3000,
@@ -169282,12 +172075,12 @@
 				"label": "Weakening Breath",
 				"menu": "templatefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
+				"moduleVersion": "2.1.0",
+				"version": "51"
 			}
 		},
 		{
-			"id": "793",
+			"id": "806",
 			"label": "Web",
 			"macro": {
 				"enable": false,
@@ -169463,7 +172256,7 @@
 			}
 		},
 		{
-			"id": "794",
+			"id": "807",
 			"label": "Weird",
 			"macro": {
 				"enable": false,
@@ -169652,7 +172445,7 @@
 			}
 		},
 		{
-			"id": "795",
+			"id": "808",
 			"label": "Whirlwind",
 			"macro": {
 				"enable": false,
@@ -169842,7 +172635,7 @@
 			}
 		},
 		{
-			"id": "796",
+			"id": "809",
 			"label": "Wind Wall",
 			"macro": {
 				"enable": false,
@@ -170019,183 +172812,7 @@
 			}
 		},
 		{
-			"id": "797",
-			"label": "Wither and Bloom",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"options": {
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0,
-					"occlusionMode": 0,
-					"opacity": 1,
-					"persistent": false,
-					"persistType": "attachtemplate",
-					"removeTemplate": true,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"rotate": 0,
-					"scale": "1, 1",
-					"zIndex": 0
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-1.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "outpulse",
-					"variant": "02",
-					"color": "greenorange",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Wither and Bloom",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 5
-			}
-		},
-		{
-			"id": "798",
+			"id": "810",
 			"label": "Word of Radiance",
 			"macro": {
 				"enable": false,
@@ -170385,7 +173002,7 @@
 			}
 		},
 		{
-			"id": "799",
+			"id": "811",
 			"label": "Wrath of Nature",
 			"macro": {
 				"enable": false,
@@ -170575,7 +173192,7 @@
 			}
 		},
 		{
-			"id": "800",
+			"id": "812",
 			"label": "Wrath of the Sea",
 			"macro": {
 				"enable": false,
@@ -170765,7 +173382,7 @@
 			}
 		},
 		{
-			"id": "801",
+			"id": "813",
 			"label": "Zone of Truth",
 			"macro": {
 				"enable": false,
@@ -170939,11 +173556,1514 @@
 				"moduleVersion": "2.0.0",
 				"version": 5
 			}
+		},
+		{
+			"id": "814",
+			"label": "Control Flames",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "calllightning",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.flames.01.orange"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-flamethrower-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": true,
+					"persistType": "attachtemplate",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "2.5",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Control Flames",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "815",
+			"label": "Detonate Eldritch Cannon",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "explosion",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Explosion/explosion-echo-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Detonate Eldritch Cannon",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "816",
+			"label": "Distort Value",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "calllightning",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.glint.yellow.many"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": true,
+					"persistType": "attachtemplate",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "5",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Distort Value",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "817",
+			"label": "Flamethrower",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "cone",
+					"animation": "breathweapon",
+					"variant": "fire01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.breath_weapons02.burst.cone.fire.orange.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-flamethrower-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 2000,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Flamethrower",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "818",
+			"label": "Frost Fingers",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0,
+					"occlusionMode": 0,
+					"opacity": 0.75,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"rotate": 0,
+					"scale": "1, 1",
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "psfx.5th-level-spells.cone-of-cold.v1.001",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "cone",
+					"animation": "coneofcold",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Frost Fingers",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "819",
+			"label": "Gate Seal",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "magicsign",
+					"variant": "abjuration",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-ticking-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": true,
+					"persistType": "attachtemplate",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Gate Seal",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "820",
+			"label": "Protector",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "outpulse",
+					"variant": "02",
+					"color": "whiteblue",
+					"enableCustom": true,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Protector",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "821",
+			"label": "Wither and Bloom",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0,
+					"occlusionMode": 0,
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "attachtemplate",
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"rotate": 0,
+					"scale": "1, 1",
+					"zIndex": 0,
+					"tint": true,
+					"tintColor": "#00ff00"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-1.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "outpulse",
+					"variant": "02",
+					"color": "yellowwhite",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_strands.overlay.dark_green.01"
+				}
+			},
+			"metaData": {
+				"label": "Wither and Bloom",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
 		}
 	],
 	"preset": [
 		{
-			"id": "802",
+			"id": "822",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -171036,7 +175156,7 @@
 			},
 			"menu": "preset",
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -171048,12 +175168,12 @@
 				"label": "Arcane Charge",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "803",
+			"id": "823",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -171146,7 +175266,7 @@
 			},
 			"menu": "preset",
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -171158,12 +175278,12 @@
 				"label": "Bewitching Magic",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "804",
+			"id": "824",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -171362,7 +175482,7 @@
 			}
 		},
 		{
-			"id": "805",
+			"id": "825",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -171461,7 +175581,7 @@
 			}
 		},
 		{
-			"id": "806",
+			"id": "826",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -171645,7 +175765,7 @@
 				}
 			},
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -171657,12 +175777,12 @@
 				"label": "Conjure Barrage",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "807",
+			"id": "827",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -171730,7 +175850,7 @@
 						"repeatDelay": 250,
 						"scale": 0.03,
 						"wait": -1000,
-						"aboveTemplate": true
+						"aboveTemplate": false
 					},
 					"sound": {
 						"enable": false,
@@ -171846,8 +175966,8 @@
 				"label": "Delayed Blast Fireball",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 6
+				"moduleVersion": "2.1.0",
+				"version": "61"
 			},
 			"advanced": {
 				"exactMatch": true,
@@ -171860,7 +175980,7 @@
 			}
 		},
 		{
-			"id": "808",
+			"id": "828",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -171959,11 +176079,11 @@
 				"label": "Dimension Door",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 6
+				"moduleVersion": "2.1.0",
+				"version": "61"
 			},
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -171973,7 +176093,7 @@
 			}
 		},
 		{
-			"id": "809",
+			"id": "829",
 			"data": {
 				"video": {
 					"dbSection": "range",
@@ -172017,7 +176137,7 @@
 				}
 			},
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -172029,12 +176149,12 @@
 				"label": "Enervation",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "810",
+			"id": "830",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -172129,11 +176249,11 @@
 				"label": "Far Step",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 6
+				"moduleVersion": "2.1.0",
+				"version": "61"
 			},
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -172143,206 +176263,7 @@
 			}
 		},
 		{
-			"id": "811",
-			"data": {
-				"projectile": {
-					"dbSection": "range",
-					"menuType": "spell",
-					"animation": "fireballbeam",
-					"variant": "01",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": "",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"removeTemplate": false,
-						"wait": -1800
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 1,
-						"file": "psfx.3rd-level-spells.fireball.v1.001.beam"
-					}
-				},
-				"preExplosion": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1,
-						"wait": 0
-					},
-					"enable": false,
-					"sound": {
-						"enable": false,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75
-					}
-				},
-				"explosion": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "fireball",
-					"variant": "explode",
-					"color": "orange",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1.25,
-						"wait": -1000,
-						"aboveTemplate": true
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 1,
-						"file": "psfx.3rd-level-spells.fireball.v1.001.explosion"
-					}
-				},
-				"afterImage": {
-					"enable": false,
-					"customPath": "",
-					"options": {
-						"elevation": 0,
-						"persistent": false,
-						"scale": 1
-					}
-				}
-			},
-			"label": "Fireball",
-			"macro": {
-				"enable": true,
-				"playWhen": "0"
-			},
-			"menu": "preset",
-			"presetType": "proToTemp",
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": true,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Fireball",
-				"menu": "preset",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "812",
+			"id": "831",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -172446,7 +176367,7 @@
 			}
 		},
 		{
-			"id": "813",
+			"id": "832",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -172514,7 +176435,7 @@
 						"repeatDelay": 250,
 						"scale": 1.25,
 						"wait": -1000,
-						"aboveTemplate": true
+						"aboveTemplate": false
 					},
 					"sound": {
 						"enable": true,
@@ -172642,12 +176563,12 @@
 				"label": "Freezing Sphere",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
 			}
 		},
 		{
-			"id": "814",
+			"id": "833",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -172844,7 +176765,7 @@
 			}
 		},
 		{
-			"id": "815",
+			"id": "834",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -172908,7 +176829,7 @@
 					"sound": {
 						"delay": 0,
 						"enable": false,
-						"file": "",
+						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-blast-1.mp3",
 						"startTime": 0,
 						"volume": 0.75,
 						"repeat": 1,
@@ -173033,7 +176954,7 @@
 			}
 		},
 		{
-			"id": "816",
+			"id": "835",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -173129,11 +177050,11 @@
 				"label": "Misty Step",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 6
+				"moduleVersion": "2.1.0",
+				"version": "61"
 			},
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -173143,7 +177064,7 @@
 			}
 		},
 		{
-			"id": "817",
+			"id": "836",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -173248,7 +177169,7 @@
 			}
 		},
 		{
-			"id": "818",
+			"id": "837",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -173352,7 +177273,7 @@
 			}
 		},
 		{
-			"id": "819",
+			"id": "838",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -173451,7 +177372,7 @@
 			}
 		},
 		{
-			"id": "820",
+			"id": "839",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -173550,7 +177471,7 @@
 			}
 		},
 		{
-			"id": "821",
+			"id": "840",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -173747,205 +177668,7 @@
 			}
 		},
 		{
-			"id": "822",
-			"data": {
-				"projectile": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "snowball",
-					"variant": "01",
-					"color": "white",
-					"enableCustom": false,
-					"customPath": "",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 5,
-						"repeatDelay": 250,
-						"removeTemplate": true,
-						"wait": -1800
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75,
-						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-1.mp3"
-					}
-				},
-				"preExplosion": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1,
-						"wait": 0
-					},
-					"enable": false,
-					"sound": {
-						"enable": false,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75
-					}
-				},
-				"explosion": {
-					"dbSection": "static",
-					"menuType": "ice",
-					"animation": "snowflake",
-					"variant": "01",
-					"color": "whiteblue",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1.25,
-						"wait": -1000,
-						"aboveTemplate": true
-					},
-					"sound": {
-						"enable": false,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75
-					}
-				},
-				"afterImage": {
-					"enable": false,
-					"customPath": "",
-					"options": {
-						"elevation": 0,
-						"persistent": false,
-						"scale": 1
-					}
-				}
-			},
-			"label": "Snilloc's Snowball Swarm",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "preset",
-			"presetType": "proToTemp",
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": true,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Snilloc's Snowball Swarm",
-				"menu": "preset",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
-			}
-		},
-		{
-			"id": "823",
+			"id": "841",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -174054,7 +177777,7 @@
 			}
 		},
 		{
-			"id": "824",
+			"id": "842",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -174158,7 +177881,7 @@
 			}
 		},
 		{
-			"id": "825",
+			"id": "843",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -174268,7 +177991,7 @@
 			}
 		},
 		{
-			"id": "826",
+			"id": "844",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -174377,7 +178100,7 @@
 			}
 		},
 		{
-			"id": "827",
+			"id": "845",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -174486,7 +178209,7 @@
 			}
 		},
 		{
-			"id": "828",
+			"id": "846",
 			"data": {
 				"video": {
 					"dbSection": "static",
@@ -174543,7 +178266,7 @@
 			}
 		},
 		{
-			"id": "829",
+			"id": "847",
 			"macro": {
 				"enable": false,
 				"playWhen": "0"
@@ -174602,7 +178325,7 @@
 			}
 		},
 		{
-			"id": "830",
+			"id": "848",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -174701,7 +178424,7 @@
 			}
 		},
 		{
-			"id": "831",
+			"id": "849",
 			"data": {
 				"video": {
 					"dbSection": "range",
@@ -174752,7 +178475,7 @@
 			}
 		},
 		{
-			"id": "832",
+			"id": "850",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -174943,7 +178666,7 @@
 				}
 			},
 			"advanced": {
-				"exactMatch": true,
+				"exactMatch": false,
 				"excludedTerms": [],
 				"excludedType": {
 					"enabled": false,
@@ -174955,12 +178678,12 @@
 				"label": "Vitriolic Sphere",
 				"menu": "preset",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1688375801432
+				"moduleVersion": "2.1.0",
+				"version": "16883758014321"
 			}
 		},
 		{
-			"id": "833",
+			"id": "851",
 			"data": {
 				"video": {
 					"dbSection": "range",
@@ -175018,12 +178741,716 @@
 					"property": ""
 				}
 			}
+		},
+		{
+			"id": "852",
+			"data": {
+				"projectile": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "fireballbeam",
+					"variant": "01",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": "",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"removeTemplate": false,
+						"wait": -1800
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 1,
+						"file": "psfx.3rd-level-spells.fireball.v1.001.beam"
+					}
+				},
+				"preExplosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"enable": false,
+					"sound": {
+						"enable": false,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75
+					}
+				},
+				"explosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "fireball",
+					"variant": "explode",
+					"color": "orange",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1.25,
+						"wait": -1000,
+						"aboveTemplate": false
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 1,
+						"file": "psfx.3rd-level-spells.fireball.v1.001.explosion"
+					}
+				},
+				"afterImage": {
+					"enable": false,
+					"customPath": "",
+					"options": {
+						"elevation": 0,
+						"persistent": false,
+						"scale": 1
+					}
+				}
+			},
+			"label": "Fireball",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "proToTemp",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Fireball",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "853",
+			"data": {
+				"projectile": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "snowball",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": false,
+					"customPath": "",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 5,
+						"repeatDelay": 250,
+						"removeTemplate": false,
+						"wait": -1800
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-1.mp3"
+					}
+				},
+				"preExplosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"enable": false,
+					"sound": {
+						"enable": false,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75
+					}
+				},
+				"explosion": {
+					"dbSection": "static",
+					"menuType": "ice",
+					"animation": "snowflake",
+					"variant": "01",
+					"color": "whiteblue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1.25,
+						"wait": -1000,
+						"aboveTemplate": false
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-blast-1.mp3"
+					}
+				},
+				"afterImage": {
+					"enable": false,
+					"customPath": "",
+					"options": {
+						"elevation": 0,
+						"persistent": false,
+						"scale": 1
+					}
+				}
+			},
+			"label": "Snilloc's Snowball Swarm",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "proToTemp",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Snilloc's Snowball Swarm",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "854",
+			"data": {
+				"projectile": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "physical",
+					"color": "orange",
+					"enableCustom": true,
+					"customPath": "jb2a.ranged.card.01.projectile.01.yellow",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 30,
+						"repeatDelay": 125,
+						"removeTemplate": false,
+						"wait": 0,
+						"randomOffset": true
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 10,
+						"repeatDelay": 350,
+						"startTime": 500,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Weapons/Ranged_Arrow_Impact/arrow-impact-7.mp3"
+					}
+				},
+				"preExplosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"enable": false,
+					"sound": {
+						"enable": false,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75
+					}
+				},
+				"explosion": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "impact",
+					"variant": "01",
+					"color": "orange",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 500,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Weapons/Ranged_Arrow_Impact/arrow-impact-7.mp3"
+					},
+					"enableCustom": true,
+					"customPath": "jb2a.ranged.card.01.projectile.01.yellow"
+				},
+				"afterImage": {
+					"enable": false,
+					"customPath": "",
+					"options": {
+						"elevation": 0,
+						"persistent": false,
+						"scale": 1
+					}
+				}
+			},
+			"label": "Spray of Cards",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "proToTemp",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 10,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Spray of Cards",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "855",
+			"data": {
+				"start": {
+					"dbSection": "static",
+					"enabe": true,
+					"menuType": "spell",
+					"animation": "mistystep",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"delay": 0,
+						"elevation": 1000,
+						"fadeIn": 250,
+						"fadeOut": 250,
+						"isMasked": false,
+						"opacity": 1,
+						"isRadius": false,
+						"playbackRate": 1,
+						"size": 1.5
+					},
+					"enable": true,
+					"enableCustom": true,
+					"customPath": "jb2a.burrow.out.01.brown"
+				},
+				"between": {
+					"dbSection": "range",
+					"enable": true,
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular",
+					"options": {
+						"delay": 0,
+						"elevation": 800,
+						"opacity": 1,
+						"playbackRate": 1
+					},
+					"enableCustom": true,
+					"customPath": "jb2a.burrow.ranged.01.brown"
+				},
+				"end": {
+					"dbSection": "static",
+					"enabe": true,
+					"menuType": "spell",
+					"animation": "mistystep",
+					"variant": "02",
+					"color": "blue",
+					"options": {
+						"delay": 2500,
+						"elevation": 1000,
+						"fadeIn": 250,
+						"fadeOut": 250,
+						"isMasked": false,
+						"isRadius": false,
+						"opacity": 1,
+						"playbackRate": 1,
+						"size": 1.5
+					},
+					"enable": true,
+					"enableCustom": true,
+					"customPath": "jb2a.burrow.out.01.brown"
+				},
+				"options": {
+					"range": 30,
+					"hideFromPlayers": false,
+					"measureType": "alternating",
+					"teleport": true,
+					"speed": 120,
+					"delayMove": 2600,
+					"alpha": 0,
+					"delayFade": 750,
+					"delayReturn": 250,
+					"checkCollision": false
+				},
+				"sound": {
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-earth-moving-1.mp3"
+				}
+			},
+			"label": "Tunneler",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "teleportation",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"metaData": {
+				"label": "Tunneler",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
 		}
 	],
 	"aura": [],
 	"aefx": [
 		{
-			"id": "834",
+			"id": "856",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
 			"secondary": {
@@ -175084,7 +179511,7 @@
 					"repeatDelay": 250,
 					"startTime": 0,
 					"volume": 0.75,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-1.mp3"
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3"
 				}
 			},
 			"macro": {
@@ -175159,7 +179586,7 @@
 			}
 		},
 		{
-			"id": "835",
+			"id": "857",
 			"label": "Antilife Shell",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -175307,7 +179734,7 @@
 			}
 		},
 		{
-			"id": "836",
+			"id": "858",
 			"label": "Antimagic Field",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -175461,7 +179888,7 @@
 			}
 		},
 		{
-			"id": "837",
+			"id": "859",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
 			"secondary": {
@@ -175597,7 +180024,7 @@
 			}
 		},
 		{
-			"id": "838",
+			"id": "860",
 			"label": "Armor of Agathys",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -175753,7 +180180,7 @@
 			}
 		},
 		{
-			"id": "839",
+			"id": "861",
 			"label": "Aura of ",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -175907,7 +180334,7 @@
 			}
 		},
 		{
-			"id": "840",
+			"id": "862",
 			"label": "Aura of Annihilation",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -176061,7 +180488,7 @@
 			}
 		},
 		{
-			"id": "841",
+			"id": "863",
 			"label": "Aura of Life",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -176215,7 +180642,7 @@
 			}
 		},
 		{
-			"id": "842",
+			"id": "864",
 			"label": "Aura of Purity",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -176369,7 +180796,7 @@
 			}
 		},
 		{
-			"id": "843",
+			"id": "865",
 			"label": "Aura of Vitality",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -176523,7 +180950,7 @@
 			}
 		},
 		{
-			"id": "844",
+			"id": "866",
 			"label": "Avenging Angel",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -176671,7 +181098,7 @@
 			}
 		},
 		{
-			"id": "845",
+			"id": "867",
 			"label": "Bane",
 			"menu": "aefx",
 			"secondary": {
@@ -176809,7 +181236,7 @@
 			}
 		},
 		{
-			"id": "846",
+			"id": "868",
 			"label": "Bardic Inspiration",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -176956,7 +181383,7 @@
 			}
 		},
 		{
-			"id": "847",
+			"id": "869",
 			"label": "Barkskin",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -177116,7 +181543,7 @@
 			}
 		},
 		{
-			"id": "848",
+			"id": "870",
 			"label": "Bastion of Law",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -177264,7 +181691,7 @@
 			}
 		},
 		{
-			"id": "849",
+			"id": "871",
 			"label": "Blade Ward",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -177412,7 +181839,7 @@
 			}
 		},
 		{
-			"id": "850",
+			"id": "872",
 			"label": "Bless",
 			"menu": "aefx",
 			"macro": {
@@ -177551,7 +181978,7 @@
 			}
 		},
 		{
-			"id": "851",
+			"id": "873",
 			"label": "Blue Light",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -177698,7 +182125,7 @@
 			}
 		},
 		{
-			"id": "852",
+			"id": "874",
 			"label": "Blur",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -177855,7 +182282,7 @@
 			}
 		},
 		{
-			"id": "853",
+			"id": "875",
 			"label": "Charmed",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -178002,7 +182429,7 @@
 			}
 		},
 		{
-			"id": "854",
+			"id": "876",
 			"label": "Chill Shield",
 			"menu": "aefx",
 			"primary": {
@@ -178144,7 +182571,7 @@
 			}
 		},
 		{
-			"id": "855",
+			"id": "877",
 			"label": "Circle of Power",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -178298,7 +182725,7 @@
 			}
 		},
 		{
-			"id": "856",
+			"id": "878",
 			"label": "Comic Dancing",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -178445,7 +182872,7 @@
 			}
 		},
 		{
-			"id": "857",
+			"id": "879",
 			"label": "Concentrating: Sunbeam",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -178592,7 +183019,7 @@
 			}
 		},
 		{
-			"id": "858",
+			"id": "880",
 			"label": "Concentrating: Yolande's Regal Presence",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -178746,7 +183173,7 @@
 			}
 		},
 		{
-			"id": "859",
+			"id": "881",
 			"label": "Confused",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -178902,7 +183329,7 @@
 			}
 		},
 		{
-			"id": "860",
+			"id": "882",
 			"label": "Conjure Woodland Beings",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -179056,7 +183483,7 @@
 			}
 		},
 		{
-			"id": "861",
+			"id": "883",
 			"label": "Conjured Minor Elementals",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -179210,7 +183637,7 @@
 			}
 		},
 		{
-			"id": "862",
+			"id": "884",
 			"label": "Contagion: Poison",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -179361,7 +183788,7 @@
 			}
 		},
 		{
-			"id": "863",
+			"id": "885",
 			"label": "Control Water",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -179509,7 +183936,7 @@
 			}
 		},
 		{
-			"id": "864",
+			"id": "886",
 			"label": "Covered in Acid",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -179656,7 +184083,7 @@
 			}
 		},
 		{
-			"id": "865",
+			"id": "887",
 			"label": "Crown of Madness: Charmed",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -179804,7 +184231,7 @@
 			}
 		},
 		{
-			"id": "866",
+			"id": "888",
 			"label": "Crusader's Mantle",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -179958,7 +184385,7 @@
 			}
 		},
 		{
-			"id": "867",
+			"id": "889",
 			"label": "Detect Evil and Good",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -180112,7 +184539,7 @@
 			}
 		},
 		{
-			"id": "868",
+			"id": "890",
 			"label": "Detect Magic",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -180266,7 +184693,7 @@
 			}
 		},
 		{
-			"id": "869",
+			"id": "891",
 			"label": "Detect Poison and Disease",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -180420,7 +184847,7 @@
 			}
 		},
 		{
-			"id": "870",
+			"id": "892",
 			"label": "Diminish Defiance",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -180568,7 +184995,7 @@
 			}
 		},
 		{
-			"id": "871",
+			"id": "893",
 			"label": "Dragon Wings",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -180717,7 +185144,7 @@
 			}
 		},
 		{
-			"id": "872",
+			"id": "894",
 			"label": "Elemental Attunement",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -180864,7 +185291,7 @@
 			}
 		},
 		{
-			"id": "873",
+			"id": "895",
 			"label": "Encased",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181012,7 +185439,7 @@
 			}
 		},
 		{
-			"id": "874",
+			"id": "896",
 			"label": "Ensnaring Strike: Restrained",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181159,7 +185586,7 @@
 			}
 		},
 		{
-			"id": "875",
+			"id": "897",
 			"label": "Entangle: Restrained",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181306,7 +185733,7 @@
 			}
 		},
 		{
-			"id": "876",
+			"id": "898",
 			"label": "Enthralled",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181453,7 +185880,7 @@
 			}
 		},
 		{
-			"id": "877",
+			"id": "899",
 			"label": "Expeditious Retreat",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181600,7 +186027,7 @@
 			}
 		},
 		{
-			"id": "878",
+			"id": "900",
 			"label": "Fire Shield",
 			"menu": "aefx",
 			"primary": {
@@ -181742,7 +186169,7 @@
 			}
 		},
 		{
-			"id": "879",
+			"id": "901",
 			"label": "Flesh to Stone: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181889,7 +186316,7 @@
 			}
 		},
 		{
-			"id": "880",
+			"id": "902",
 			"label": "Glittering",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182036,7 +186463,7 @@
 			}
 		},
 		{
-			"id": "881",
+			"id": "903",
 			"label": "Green Light",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182183,7 +186610,7 @@
 			}
 		},
 		{
-			"id": "882",
+			"id": "904",
 			"label": "Haste",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182340,7 +186767,7 @@
 			}
 		},
 		{
-			"id": "883",
+			"id": "905",
 			"label": "Heat Metal: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182488,7 +186915,7 @@
 			}
 		},
 		{
-			"id": "884",
+			"id": "906",
 			"label": "Hold Monster: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182635,7 +187062,7 @@
 			}
 		},
 		{
-			"id": "885",
+			"id": "907",
 			"label": "Hold Person: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182782,7 +187209,7 @@
 			}
 		},
 		{
-			"id": "886",
+			"id": "908",
 			"label": "Holy Aura (Aura)",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -182936,7 +187363,7 @@
 			}
 		},
 		{
-			"id": "887",
+			"id": "909",
 			"label": "Hypnotic Pattern: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183083,7 +187510,7 @@
 			}
 		},
 		{
-			"id": "888",
+			"id": "910",
 			"label": "Imprisonment: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183230,7 +187657,155 @@
 			}
 		},
 		{
-			"id": "889",
+			"id": "911",
+			"label": "Intellect Fortress",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "energyfield",
+					"variant": "01",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Intellect Fortress",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": "17414735301001"
+			}
+		},
+		{
+			"id": "912",
 			"label": "Laughing Uncontrollably",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183377,7 +187952,7 @@
 			}
 		},
 		{
-			"id": "890",
+			"id": "913",
 			"label": "Living Legend",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183529,7 +188104,7 @@
 			}
 		},
 		{
-			"id": "891",
+			"id": "914",
 			"label": "Longstrider",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183676,7 +188251,7 @@
 			}
 		},
 		{
-			"id": "892",
+			"id": "915",
 			"label": "Mage Armor",
 			"menu": "aefx",
 			"secondary": {
@@ -183814,7 +188389,7 @@
 			}
 		},
 		{
-			"id": "893",
+			"id": "916",
 			"label": "Mass Suggestion",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183961,7 +188536,7 @@
 			}
 		},
 		{
-			"id": "894",
+			"id": "917",
 			"label": "Pass without Trace",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -184115,7 +188690,7 @@
 			}
 		},
 		{
-			"id": "895",
+			"id": "918",
 			"label": "Peerless Athlete",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184263,7 +188838,7 @@
 			}
 		},
 		{
-			"id": "896",
+			"id": "919",
 			"label": "Protection from Acid",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184411,7 +188986,7 @@
 			}
 		},
 		{
-			"id": "897",
+			"id": "920",
 			"label": "Protection from Cold",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184559,7 +189134,7 @@
 			}
 		},
 		{
-			"id": "898",
+			"id": "921",
 			"label": "Protection from Fire",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184707,7 +189282,7 @@
 			}
 		},
 		{
-			"id": "899",
+			"id": "922",
 			"label": "Protection from Lightning",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184855,7 +189430,7 @@
 			}
 		},
 		{
-			"id": "900",
+			"id": "923",
 			"label": "Protection from Thunder",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185003,7 +189578,7 @@
 			}
 		},
 		{
-			"id": "901",
+			"id": "924",
 			"label": "Rage",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185150,7 +189725,7 @@
 			}
 		},
 		{
-			"id": "902",
+			"id": "925",
 			"label": "Resistance: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185298,7 +189873,7 @@
 			}
 		},
 		{
-			"id": "903",
+			"id": "926",
 			"label": "Shield",
 			"menu": "aefx",
 			"primary": {
@@ -185440,7 +190015,7 @@
 			}
 		},
 		{
-			"id": "904",
+			"id": "927",
 			"label": "Shield of Faith",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185597,7 +190172,7 @@
 			}
 		},
 		{
-			"id": "905",
+			"id": "928",
 			"label": "Sleep: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185744,7 +190319,7 @@
 			}
 		},
 		{
-			"id": "906",
+			"id": "929",
 			"label": "Slow",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185901,7 +190476,7 @@
 			}
 		},
 		{
-			"id": "907",
+			"id": "930",
 			"label": "Spirit Guardians",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -186064,161 +190639,7 @@
 			}
 		},
 		{
-			"id": "908",
-			"label": "Spirit Shroud",
-			"activeEffectType": "aura",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "spiritguardians",
-					"variant": "noring",
-					"color": "lightgreen",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": true,
-					"alpha": false,
-					"alphaMax": 0.5,
-					"alphaMin": -0.5,
-					"alphaDuration": 1000,
-					"breath": false,
-					"breathMax": 1.05,
-					"breathMin": 0.95,
-					"breathDuration": 1000,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"playOn": "source",
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"tintSaturate": 0,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Spirit Shroud",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
-			}
-		},
-		{
-			"id": "909",
+			"id": "931",
 			"label": "Starry Form",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186366,7 +190787,7 @@
 			}
 		},
 		{
-			"id": "910",
+			"id": "932",
 			"label": "Stonecunning: Tremorsense",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -186519,7 +190940,7 @@
 			}
 		},
 		{
-			"id": "911",
+			"id": "933",
 			"label": "Stoneskin",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186667,7 +191088,7 @@
 			}
 		},
 		{
-			"id": "912",
+			"id": "934",
 			"label": "Suggestion",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186823,7 +191244,161 @@
 			}
 		},
 		{
-			"id": "913",
+			"id": "935",
+			"label": "Surrounded by a Spirit Shroud",
+			"activeEffectType": "aura",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "spiritguardians",
+					"variant": "noring",
+					"color": "lightgreen",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": true,
+					"alpha": false,
+					"alphaMax": 0.5,
+					"alphaMin": -0.5,
+					"alphaDuration": 1000,
+					"breath": false,
+					"breathMax": 1.05,
+					"breathMin": 0.95,
+					"breathDuration": 1000,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"playOn": "source",
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"tintSaturate": 0,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Surrounded by a Spirit Shroud",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": "17405663085101"
+			}
+		},
+		{
+			"id": "936",
 			"label": "Synaptic Static: Muddled Thoughts",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186970,7 +191545,7 @@
 			}
 		},
 		{
-			"id": "914",
+			"id": "937",
 			"label": "Unbreakable Majesty",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187118,7 +191693,7 @@
 			}
 		},
 		{
-			"id": "915",
+			"id": "938",
 			"label": "Vicious Mockery",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187265,7 +191840,7 @@
 			}
 		},
 		{
-			"id": "916",
+			"id": "939",
 			"label": "Violet Light",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187412,7 +191987,7 @@
 			}
 		},
 		{
-			"id": "917",
+			"id": "940",
 			"label": "Warm Shield",
 			"menu": "aefx",
 			"primary": {
@@ -187554,7 +192129,7 @@
 			}
 		},
 		{
-			"id": "918",
+			"id": "941",
 			"label": "Wreathed in Moonlight",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187704,7 +192279,7 @@
 			}
 		},
 		{
-			"id": "919",
+			"id": "942",
 			"label": "Yolande's Regal Presence: Prone",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187852,6 +192427,1942 @@
 				"name": "5e Animations",
 				"moduleVersion": "2.0.0",
 				"version": 1740566308510
+			}
+		},
+		{
+			"id": "943",
+			"label": "Absorb Acid",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "green",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Acid",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "944",
+			"label": "Absorb Cold",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Cold",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "945",
+			"label": "Absorb Fire",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"saturation": 1,
+					"tintColor": "#ff0000",
+					"contrast": null
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Fire",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "946",
+			"label": "Absorb Lightning",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Lightning",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "947",
+			"label": "Absorb Thunder",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"saturation": -1,
+					"contrast": 0.75
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Thunder",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "948",
+			"label": "Concentrating: Investiture of Flame",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "fire",
+					"variant": "03",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "red",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Flame",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "949",
+			"label": "Concentrating: Investiture of Ice",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "ice",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Ice",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "950",
+			"label": "Concentrating: Investiture of Stone",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "earth",
+					"variant": "03",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-earth-moving-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Stone",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "951",
+			"label": "Concentrating: Investiture of Wind",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "earth",
+					"variant": "01",
+					"color": "darkorange",
+					"enableCustom": true,
+					"customPath": "jb2a.template_circle.vortex.loop.dark_black"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.5,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"saturation": -1,
+					"tintColor": "#ffffff",
+					"contrast": 0.5
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-wind-gust-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0.5,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": true,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1,
+					"saturation": -1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Wind",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "952",
+			"label": "Draconic Transformation",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "modules/dnd5e-animations/assets/graphics/DragonWings.webp"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5,0.65",
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 2,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Creatures/Growl/growl-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.aura_themed.01.outward.complete.metal.01.red"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Draconic Transformation",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "953",
+			"label": "Invulnerability",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "tokenborder",
+					"animation": "spinning",
+					"variant": "04",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "abjuration",
+					"variant": "complete",
+					"color": "darkblue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Invulnerability",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "954",
+			"label": "Primordial Ward",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "eldritchweb",
+					"variant": "01",
+					"color": "darkpurple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-barrier-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Primordial Ward",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
+			}
+		},
+		{
+			"id": "955",
+			"label": "Wielding Shadow Blade",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.spiritual_weapon.sword.dark.purple"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Wielding Shadow Blade",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.0",
+				"version": 1741827752760
 			}
 		}
 	],


### PR DESCRIPTION
I gave the original 2.0.0 a couple of weeks of beta to see if there were any complaints, but I haven't heard any so I'm pushing this one out as a full release! But 2.1.0 isn't just moving 2.0.0 into the main release channel. I reviewed the spells of most of what is considered 1st party Expanded Rules content such as, but not limited to, Tasha's Cauldron of Everything and Xanathar's Guide to Everything. I added some missing bits such as the spells of Acquisitions Incorporated and a few others. I also made sure to review and add new animation configurations for Artificers. It's hard for me to write down all the changes in this release, so you'll have to discover them yourselves :3

For those not updating from the 2.0.0 beta release, **IT IS HIGHLY RECOMMENDED TO GO INTO THE AUTOMATED ANIMATIONS GLOBAL AUTOMATIC RECOGNITION MENU AND RESTORE DEFAULT MENU BEFORE UPDATING TO START OFF FRESH**! This is because there are so many changes to the config that several items have been moved from one tab to the other and to be 100% sure the update goes smoothly, I suggest starting from a fresh slate unless you have a lot of custom animations. If you already did this when trying out 2.0.0 you should be fine thanks to Vauxs' updating an important piece of code for me to update the version numbers of each animation configuration. Thank you again Vauxs! 