### PR TITLE
Paladin Aura Update - V2.1.1

### DIFF
--- a/module/autorec.json
+++ b/module/autorec.json
@@ -4467,6 +4467,231 @@
 		},
 		{
 			"id": "20",
+			"label": "Force-Empowered Rend",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_generic.slash.02.002.purple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Force-Empowered Rend",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "21",
 			"label": "Fork",
 			"levels3d": {
 				"type": "slash",
@@ -4700,7 +4925,7 @@
 			}
 		},
 		{
-			"id": "21",
+			"id": "22",
 			"label": "Glaive",
 			"levels3d": {
 				"type": "explosion",
@@ -4925,7 +5150,7 @@
 			}
 		},
 		{
-			"id": "22",
+			"id": "23",
 			"label": "Greataxe",
 			"levels3d": {
 				"type": "explosion",
@@ -5150,7 +5375,7 @@
 			}
 		},
 		{
-			"id": "23",
+			"id": "24",
 			"label": "Greatclub",
 			"levels3d": {
 				"type": "explosion",
@@ -5375,7 +5600,7 @@
 			}
 		},
 		{
-			"id": "24",
+			"id": "25",
 			"label": "Greatsword",
 			"levels3d": {
 				"type": "explosion",
@@ -5600,7 +5825,7 @@
 			}
 		},
 		{
-			"id": "25",
+			"id": "26",
 			"label": "Halberd",
 			"levels3d": {
 				"type": "explosion",
@@ -5825,7 +6050,7 @@
 			}
 		},
 		{
-			"id": "26",
+			"id": "27",
 			"label": "Hammer",
 			"levels3d": {
 				"type": "explosion",
@@ -6052,7 +6277,7 @@
 			}
 		},
 		{
-			"id": "27",
+			"id": "28",
 			"label": "Handaxe",
 			"levels3d": {
 				"type": "explosion",
@@ -6278,7 +6503,7 @@
 			}
 		},
 		{
-			"id": "28",
+			"id": "29",
 			"label": "Harpoon",
 			"levels3d": {
 				"enable": true,
@@ -6514,7 +6739,7 @@
 			}
 		},
 		{
-			"id": "29",
+			"id": "30",
 			"label": "Hoof",
 			"levels3d": {
 				"type": "slash",
@@ -6741,7 +6966,7 @@
 			}
 		},
 		{
-			"id": "30",
+			"id": "31",
 			"label": "Hook",
 			"levels3d": {
 				"type": "slash",
@@ -6968,7 +7193,7 @@
 			}
 		},
 		{
-			"id": "31",
+			"id": "32",
 			"label": "Hooves",
 			"levels3d": {
 				"enable": true,
@@ -7204,7 +7429,7 @@
 			}
 		},
 		{
-			"id": "32",
+			"id": "33",
 			"label": "Horn",
 			"levels3d": {
 				"enable": true,
@@ -7442,7 +7667,7 @@
 			}
 		},
 		{
-			"id": "33",
+			"id": "34",
 			"label": "Interception",
 			"levels3d": {
 				"type": "explosion",
@@ -7667,7 +7892,7 @@
 			}
 		},
 		{
-			"id": "34",
+			"id": "35",
 			"label": "Katana",
 			"levels3d": {
 				"type": "explosion",
@@ -7894,7 +8119,7 @@
 			}
 		},
 		{
-			"id": "35",
+			"id": "36",
 			"label": "Katar",
 			"levels3d": {
 				"type": "explosion",
@@ -8119,7 +8344,7 @@
 			}
 		},
 		{
-			"id": "36",
+			"id": "37",
 			"label": "Knife",
 			"levels3d": {
 				"enable": true,
@@ -8385,7 +8610,7 @@
 			}
 		},
 		{
-			"id": "37",
+			"id": "38",
 			"label": "Lance",
 			"levels3d": {
 				"type": "explosion",
@@ -8610,7 +8835,7 @@
 			}
 		},
 		{
-			"id": "38",
+			"id": "39",
 			"label": "Lasersword",
 			"levels3d": {
 				"enable": true,
@@ -8850,7 +9075,7 @@
 			}
 		},
 		{
-			"id": "39",
+			"id": "40",
 			"label": "Longsword",
 			"levels3d": {
 				"type": "explosion",
@@ -9075,7 +9300,7 @@
 			}
 		},
 		{
-			"id": "40",
+			"id": "41",
 			"label": "Mace",
 			"levels3d": {
 				"type": "explosion",
@@ -9300,7 +9525,7 @@
 			}
 		},
 		{
-			"id": "41",
+			"id": "42",
 			"label": "Machete",
 			"levels3d": {
 				"type": "explosion",
@@ -9525,7 +9750,7 @@
 			}
 		},
 		{
-			"id": "42",
+			"id": "43",
 			"label": "Martial Arts",
 			"levels3d": {
 				"enable": true,
@@ -9788,7 +10013,7 @@
 			}
 		},
 		{
-			"id": "43",
+			"id": "44",
 			"label": "Maul",
 			"levels3d": {
 				"type": "explosion",
@@ -10013,7 +10238,7 @@
 			}
 		},
 		{
-			"id": "44",
+			"id": "45",
 			"label": "Morningstar",
 			"levels3d": {
 				"type": "explosion",
@@ -10238,7 +10463,7 @@
 			}
 		},
 		{
-			"id": "45",
+			"id": "46",
 			"label": "Naginata",
 			"levels3d": {
 				"enable": true,
@@ -10476,7 +10701,234 @@
 			}
 		},
 		{
-			"id": "46",
+			"id": "47",
+			"label": "Nodachi",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"name": "Compendium.dnd5e-animations.Macros.Advanced Melee Attack Macro",
+				"args": "{\n    weaponGroup: 'melee_attack.04',\n    weapon: 'katana.01',\n    enableTrail: false,\n    trail: 'trail.04',\n    color: 'blue',\n\t\n    enableSound: true,\n    soundFileMelee: 'modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*',\n    delaySound: 100\n}",
+				"playWhen": "2"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.05.nodachi"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 300,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Nodachi",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421716968261"
+			}
+		},
+		{
+			"id": "48",
 			"label": "Odachi",
 			"levels3d": {
 				"type": "explosion",
@@ -10703,7 +11155,7 @@
 			}
 		},
 		{
-			"id": "47",
+			"id": "49",
 			"label": "Open Hand Technique",
 			"levels3d": {
 				"type": "explosion",
@@ -10928,7 +11380,234 @@
 			}
 		},
 		{
-			"id": "48",
+			"id": "50",
+			"label": "Pan",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"name": "Compendium.dnd5e-animations.Macros.Advanced Melee Attack Macro",
+				"args": "{\n    weaponGroup: 'melee_attack.04',\n    weapon: 'katana.01',\n    enableTrail: false,\n    trail: 'trail.04',\n    color: 'blue',\n\t\n    enableSound: true,\n    soundFileMelee: 'modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*',\n    delaySound: 100\n}",
+				"playWhen": "2"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.pan.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 300,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Bludgeoning/melee-impact-metal-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 1000,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Pan",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421717097751"
+			}
+		},
+		{
+			"id": "51",
 			"label": "Pick",
 			"levels3d": {
 				"type": "explosion",
@@ -11153,7 +11832,7 @@
 			}
 		},
 		{
-			"id": "49",
+			"id": "52",
 			"label": "Pike",
 			"levels3d": {
 				"type": "explosion",
@@ -11378,7 +12057,7 @@
 			}
 		},
 		{
-			"id": "50",
+			"id": "53",
 			"label": "Pincer",
 			"levels3d": {
 				"type": "slash",
@@ -11605,7 +12284,232 @@
 			}
 		},
 		{
-			"id": "51",
+			"id": "54",
+			"label": "Primal Savagery",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"meleeSwitch": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"detect": "automatic",
+					"range": 2,
+					"returning": false,
+					"switchType": "on"
+				}
+			},
+			"menu": "melee",
+			"primary": {
+				"video": {
+					"dbSection": "melee",
+					"menuType": "weapon",
+					"animation": "club",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_generic.creature_attack.claw.001.green"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Acid/acid-bubbling-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 500,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isWait": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 0.75,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Primal Savagery",
+				"menu": "melee",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421717536691"
+			}
+		},
+		{
+			"id": "55",
 			"label": "Pseudopod",
 			"levels3d": {
 				"type": "slash",
@@ -11830,12 +12734,12 @@
 				"label": "Pseudopod",
 				"menu": "melee",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
+				"moduleVersion": "2.1.1",
+				"version": "16867533014171"
 			}
 		},
 		{
-			"id": "52",
+			"id": "56",
 			"label": "Quarterstaff",
 			"levels3d": {
 				"type": "explosion",
@@ -12060,7 +12964,7 @@
 			}
 		},
 		{
-			"id": "53",
+			"id": "57",
 			"label": "Quivering Palm",
 			"levels3d": {
 				"type": "explosion",
@@ -12286,7 +13190,7 @@
 			}
 		},
 		{
-			"id": "54",
+			"id": "58",
 			"label": "Ram",
 			"levels3d": {
 				"enable": true,
@@ -12523,7 +13427,7 @@
 			}
 		},
 		{
-			"id": "55",
+			"id": "59",
 			"label": "Rapier",
 			"levels3d": {
 				"type": "explosion",
@@ -12748,7 +13652,7 @@
 			}
 		},
 		{
-			"id": "56",
+			"id": "60",
 			"label": "Retaliation",
 			"levels3d": {
 				"type": "explosion",
@@ -12973,7 +13877,7 @@
 			}
 		},
 		{
-			"id": "57",
+			"id": "61",
 			"label": "Scimitar",
 			"levels3d": {
 				"type": "explosion",
@@ -13198,7 +14102,7 @@
 			}
 		},
 		{
-			"id": "58",
+			"id": "62",
 			"label": "Scythe",
 			"levels3d": {
 				"type": "slash",
@@ -13425,7 +14329,7 @@
 			}
 		},
 		{
-			"id": "59",
+			"id": "63",
 			"label": "Shield",
 			"levels3d": {
 				"type": "swing",
@@ -13661,7 +14565,7 @@
 			}
 		},
 		{
-			"id": "60",
+			"id": "64",
 			"label": "Shortsword",
 			"levels3d": {
 				"type": "explosion",
@@ -13886,7 +14790,7 @@
 			}
 		},
 		{
-			"id": "61",
+			"id": "65",
 			"label": "Sickle",
 			"levels3d": {
 				"type": "explosion",
@@ -14111,7 +15015,7 @@
 			}
 		},
 		{
-			"id": "62",
+			"id": "66",
 			"label": "Slam",
 			"levels3d": {
 				"enable": true,
@@ -14372,7 +15276,7 @@
 			}
 		},
 		{
-			"id": "63",
+			"id": "67",
 			"label": "Spear",
 			"levels3d": {
 				"type": "explosion",
@@ -14597,7 +15501,7 @@
 			}
 		},
 		{
-			"id": "64",
+			"id": "68",
 			"label": "Spike",
 			"levels3d": {
 				"type": "thrust",
@@ -14826,7 +15730,7 @@
 			}
 		},
 		{
-			"id": "65",
+			"id": "69",
 			"label": "Stab",
 			"levels3d": {
 				"type": "thrust",
@@ -15055,7 +15959,7 @@
 			}
 		},
 		{
-			"id": "66",
+			"id": "70",
 			"label": "Staff",
 			"levels3d": {
 				"type": "explosion",
@@ -15280,7 +16184,7 @@
 			}
 		},
 		{
-			"id": "67",
+			"id": "71",
 			"label": "Steel Wind Strike",
 			"levels3d": {
 				"enable": true,
@@ -15514,7 +16418,7 @@
 			}
 		},
 		{
-			"id": "68",
+			"id": "72",
 			"label": "Sting",
 			"levels3d": {
 				"enable": true,
@@ -15751,7 +16655,7 @@
 			}
 		},
 		{
-			"id": "69",
+			"id": "73",
 			"label": "Stinger",
 			"levels3d": {
 				"type": "slash",
@@ -15980,7 +16884,7 @@
 			}
 		},
 		{
-			"id": "70",
+			"id": "74",
 			"label": "Stomp",
 			"levels3d": {
 				"enable": true,
@@ -16218,7 +17122,7 @@
 			}
 		},
 		{
-			"id": "71",
+			"id": "75",
 			"label": "Strike",
 			"levels3d": {
 				"enable": true,
@@ -16480,7 +17384,7 @@
 			}
 		},
 		{
-			"id": "72",
+			"id": "76",
 			"label": "Stunning Strike",
 			"levels3d": {
 				"enable": true,
@@ -16742,7 +17646,7 @@
 			}
 		},
 		{
-			"id": "73",
+			"id": "77",
 			"label": "Sword",
 			"levels3d": {
 				"enable": true,
@@ -17006,7 +17910,7 @@
 			}
 		},
 		{
-			"id": "74",
+			"id": "78",
 			"label": "Tail",
 			"levels3d": {
 				"enable": true,
@@ -17241,7 +18145,7 @@
 			}
 		},
 		{
-			"id": "75",
+			"id": "79",
 			"label": "Tanto",
 			"levels3d": {
 				"type": "explosion",
@@ -17468,7 +18372,7 @@
 			}
 		},
 		{
-			"id": "76",
+			"id": "80",
 			"label": "Trident",
 			"levels3d": {
 				"type": "explosion",
@@ -17694,7 +18598,7 @@
 			}
 		},
 		{
-			"id": "77",
+			"id": "81",
 			"label": "Tusk",
 			"levels3d": {
 				"enable": true,
@@ -17931,7 +18835,7 @@
 			}
 		},
 		{
-			"id": "78",
+			"id": "82",
 			"label": "Unarmed",
 			"levels3d": {
 				"enable": true,
@@ -18194,7 +19098,7 @@
 			}
 		},
 		{
-			"id": "79",
+			"id": "83",
 			"label": "Unarmed Strike",
 			"levels3d": {
 				"enable": true,
@@ -18457,7 +19361,7 @@
 			}
 		},
 		{
-			"id": "80",
+			"id": "84",
 			"label": "War Pick",
 			"levels3d": {
 				"type": "explosion",
@@ -18682,7 +19586,7 @@
 			}
 		},
 		{
-			"id": "81",
+			"id": "85",
 			"label": "Warhammer",
 			"levels3d": {
 				"type": "explosion",
@@ -18907,7 +19811,7 @@
 			}
 		},
 		{
-			"id": "82",
+			"id": "86",
 			"label": "Whip",
 			"levels3d": {
 				"type": "explosion",
@@ -19132,7 +20036,7 @@
 			}
 		},
 		{
-			"id": "83",
+			"id": "87",
 			"label": "Wing",
 			"levels3d": {
 				"enable": true,
@@ -19369,7 +20273,7 @@
 			}
 		},
 		{
-			"id": "84",
+			"id": "88",
 			"label": "Wrench",
 			"levels3d": {
 				"enable": true,
@@ -19606,7 +20510,7 @@
 			}
 		},
 		{
-			"id": "85",
+			"id": "89",
 			"label": "Yklwa",
 			"levels3d": {
 				"type": "explosion",
@@ -19828,910 +20732,6 @@
 				"name": "5e Animations",
 				"moduleVersion": "2.0.0",
 				"version": 1740566308509
-			}
-		},
-		{
-			"id": "86",
-			"label": "Force-Empowered Rend",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"meleeSwitch": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "arrow",
-					"variant": "regular",
-					"color": "regular"
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"detect": "automatic",
-					"range": 2,
-					"returning": false,
-					"switchType": "on"
-				}
-			},
-			"menu": "melee",
-			"primary": {
-				"video": {
-					"dbSection": "melee",
-					"menuType": "weapon",
-					"animation": "club",
-					"variant": "01",
-					"color": "white",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_generic.slash.02.002.purple"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-3.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isWait": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Force-Empowered Rend",
-				"menu": "melee",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "87",
-			"label": "Nodachi",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"name": "Compendium.dnd5e-animations.Macros.Advanced Melee Attack Macro",
-				"args": "{\n    weaponGroup: 'melee_attack.04',\n    weapon: 'katana.01',\n    enableTrail: false,\n    trail: 'trail.04',\n    color: 'blue',\n\t\n    enableSound: true,\n    soundFileMelee: 'modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*',\n    delaySound: 100\n}",
-				"playWhen": "2"
-			},
-			"meleeSwitch": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "arrow",
-					"variant": "regular",
-					"color": "regular"
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"detect": "automatic",
-					"range": 2,
-					"returning": false,
-					"switchType": "on"
-				}
-			},
-			"menu": "melee",
-			"primary": {
-				"video": {
-					"dbSection": "melee",
-					"menuType": "weapon",
-					"animation": "club",
-					"variant": "01",
-					"color": "white",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_attack.05.nodachi"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 300,
-					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isWait": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Nodachi",
-				"menu": "melee",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "88",
-			"label": "Pan",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"name": "Compendium.dnd5e-animations.Macros.Advanced Melee Attack Macro",
-				"args": "{\n    weaponGroup: 'melee_attack.04',\n    weapon: 'katana.01',\n    enableTrail: false,\n    trail: 'trail.04',\n    color: 'blue',\n\t\n    enableSound: true,\n    soundFileMelee: 'modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/*',\n    delaySound: 100\n}",
-				"playWhen": "2"
-			},
-			"meleeSwitch": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "arrow",
-					"variant": "regular",
-					"color": "regular"
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"detect": "automatic",
-					"range": 2,
-					"returning": false,
-					"switchType": "on"
-				}
-			},
-			"menu": "melee",
-			"primary": {
-				"video": {
-					"dbSection": "melee",
-					"menuType": "weapon",
-					"animation": "club",
-					"variant": "01",
-					"color": "white",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_attack.02.pan.01"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 300,
-					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Bludgeoning/melee-impact-metal-5.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 1000,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isWait": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Pan",
-				"menu": "melee",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "89",
-			"label": "Primal Savagery",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"meleeSwitch": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "arrow",
-					"variant": "regular",
-					"color": "regular"
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"detect": "automatic",
-					"range": 2,
-					"returning": false,
-					"switchType": "on"
-				}
-			},
-			"menu": "melee",
-			"primary": {
-				"video": {
-					"dbSection": "melee",
-					"menuType": "weapon",
-					"animation": "club",
-					"variant": "01",
-					"color": "white",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_generic.creature_attack.claw.001.green"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Acid/acid-bubbling-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 500,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isWait": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 0.75,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Primal Savagery",
-				"menu": "melee",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
 			}
 		}
 	],
@@ -21230,6 +21230,210 @@
 		},
 		{
 			"id": "92",
+			"label": "Antagonize",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular",
+					"enableCustom": true,
+					"customPath": "jb2a.spell_projectile.sound.01.pinkteal"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 800,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.condition.curse.01.007.purple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "psfx.cantrips.mind-sliver.v1",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.5
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Antagonize",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "93",
 			"label": "Antimatter Rifle",
 			"levels3d": {
 				"type": "explosion",
@@ -21433,7 +21637,7 @@
 			}
 		},
 		{
-			"id": "93",
+			"id": "94",
 			"label": "Antipathy/Sympathy",
 			"levels3d": {
 				"enable": true,
@@ -21670,7 +21874,7 @@
 			}
 		},
 		{
-			"id": "94",
+			"id": "95",
 			"label": "Arcane Burst",
 			"levels3d": {
 				"enable": true,
@@ -21906,7 +22110,7 @@
 			}
 		},
 		{
-			"id": "95",
+			"id": "96",
 			"label": "Automatic",
 			"levels3d": {
 				"type": "explosion",
@@ -22109,7 +22313,7 @@
 			}
 		},
 		{
-			"id": "96",
+			"id": "97",
 			"label": "Awakened Mind",
 			"levels3d": {
 				"type": "explosion",
@@ -22312,7 +22516,7 @@
 			}
 		},
 		{
-			"id": "97",
+			"id": "98",
 			"label": "Beam",
 			"levels3d": {
 				"type": "projectile",
@@ -22521,7 +22725,7 @@
 			}
 		},
 		{
-			"id": "98",
+			"id": "99",
 			"label": "Befuddlement",
 			"levels3d": {
 				"type": "explosion",
@@ -22725,7 +22929,7 @@
 			}
 		},
 		{
-			"id": "99",
+			"id": "100",
 			"label": "Beguiling Defenses",
 			"levels3d": {
 				"type": "explosion",
@@ -22929,7 +23133,7 @@
 			}
 		},
 		{
-			"id": "100",
+			"id": "101",
 			"label": "Blood Drain",
 			"levels3d": {
 				"type": "jb2aexplosion",
@@ -23137,7 +23341,7 @@
 			}
 		},
 		{
-			"id": "101",
+			"id": "102",
 			"label": "Blowgun",
 			"levels3d": {
 				"type": "explosion",
@@ -23340,7 +23544,7 @@
 			}
 		},
 		{
-			"id": "102",
+			"id": "103",
 			"label": "Bomb",
 			"levels3d": {
 				"enable": true,
@@ -23574,7 +23778,7 @@
 			}
 		},
 		{
-			"id": "103",
+			"id": "104",
 			"label": "Boomerang",
 			"levels3d": {
 				"type": "explosion",
@@ -23777,7 +23981,7 @@
 			}
 		},
 		{
-			"id": "104",
+			"id": "105",
 			"label": "Boulder",
 			"levels3d": {
 				"enable": true,
@@ -24015,7 +24219,7 @@
 			}
 		},
 		{
-			"id": "105",
+			"id": "106",
 			"label": "Bow",
 			"levels3d": {
 				"type": "explosion",
@@ -24218,7 +24422,7 @@
 			}
 		},
 		{
-			"id": "106",
+			"id": "107",
 			"label": "Burnt Othur Fumes",
 			"levels3d": {
 				"type": "explosion",
@@ -24422,7 +24626,7 @@
 			}
 		},
 		{
-			"id": "107",
+			"id": "108",
 			"label": "Catapult",
 			"levels3d": {
 				"enable": true,
@@ -24658,7 +24862,7 @@
 			}
 		},
 		{
-			"id": "108",
+			"id": "109",
 			"label": "Catapult Munition",
 			"levels3d": {
 				"type": "explosion",
@@ -24861,7 +25065,7 @@
 			}
 		},
 		{
-			"id": "109",
+			"id": "110",
 			"label": "Chain Lightning",
 			"levels3d": {
 				"enable": true,
@@ -25104,7 +25308,7 @@
 			}
 		},
 		{
-			"id": "110",
+			"id": "111",
 			"label": "Chakram",
 			"levels3d": {
 				"enable": true,
@@ -25339,7 +25543,7 @@
 			}
 		},
 		{
-			"id": "111",
+			"id": "112",
 			"label": "Chaos Bolt",
 			"levels3d": {
 				"enable": true,
@@ -25580,7 +25784,7 @@
 			}
 		},
 		{
-			"id": "112",
+			"id": "113",
 			"label": "Chromatic Orb",
 			"levels3d": {
 				"enable": true,
@@ -25818,7 +26022,7 @@
 			}
 		},
 		{
-			"id": "113",
+			"id": "114",
 			"label": "Contagion",
 			"levels3d": {
 				"type": "castingsign",
@@ -26033,7 +26237,7 @@
 			}
 		},
 		{
-			"id": "114",
+			"id": "115",
 			"label": "Crossbow",
 			"levels3d": {
 				"type": "explosion",
@@ -26236,7 +26440,7 @@
 			}
 		},
 		{
-			"id": "115",
+			"id": "116",
 			"label": "Danse Macabre",
 			"levels3d": {
 				"type": "explosion",
@@ -26442,7 +26646,7 @@
 			}
 		},
 		{
-			"id": "116",
+			"id": "117",
 			"label": "Dart",
 			"levels3d": {
 				"type": "explosion",
@@ -26645,7 +26849,7 @@
 			}
 		},
 		{
-			"id": "117",
+			"id": "118",
 			"label": "Disintegrate",
 			"levels3d": {
 				"enable": true,
@@ -26884,7 +27088,7 @@
 			}
 		},
 		{
-			"id": "118",
+			"id": "119",
 			"label": "Draining Kiss",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -27094,7 +27298,7 @@
 			}
 		},
 		{
-			"id": "119",
+			"id": "120",
 			"label": "Dynamite",
 			"levels3d": {
 				"enable": true,
@@ -27330,7 +27534,7 @@
 			}
 		},
 		{
-			"id": "120",
+			"id": "121",
 			"label": "Eldritch Blast",
 			"levels3d": {
 				"type": "explosion",
@@ -27533,7 +27737,7 @@
 			}
 		},
 		{
-			"id": "121",
+			"id": "122",
 			"label": "Enemies Abound",
 			"levels3d": {
 				"type": "explosion",
@@ -27737,7 +27941,7 @@
 			}
 		},
 		{
-			"id": "122",
+			"id": "123",
 			"label": "Essence of Ether",
 			"levels3d": {
 				"type": "explosion",
@@ -27941,7 +28145,7 @@
 			}
 		},
 		{
-			"id": "123",
+			"id": "124",
 			"label": "Feeblemind",
 			"levels3d": {
 				"type": "runicray",
@@ -28150,7 +28354,7 @@
 			}
 		},
 		{
-			"id": "124",
+			"id": "125",
 			"label": "Finger of Death",
 			"levels3d": {
 				"enable": true,
@@ -28386,7 +28590,7 @@
 			}
 		},
 		{
-			"id": "125",
+			"id": "126",
 			"label": "Fire Bolt",
 			"levels3d": {
 				"type": "explosion",
@@ -28589,7 +28793,7 @@
 			}
 		},
 		{
-			"id": "126",
+			"id": "127",
 			"label": "Fire Ray",
 			"levels3d": {
 				"enable": true,
@@ -28823,7 +29027,210 @@
 			}
 		},
 		{
-			"id": "127",
+			"id": "128",
+			"label": "Force Ballista",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "eldritchblast",
+					"variant": "01",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "psfx.cantrips.eldritch-blast.v1",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Force Ballista",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "129",
 			"label": "Fragmentation Grenade",
 			"levels3d": {
 				"enable": true,
@@ -29059,7 +29466,7 @@
 			}
 		},
 		{
-			"id": "128",
+			"id": "130",
 			"label": "Gnomengarde Grenade",
 			"levels3d": {
 				"enable": true,
@@ -29295,7 +29702,7 @@
 			}
 		},
 		{
-			"id": "129",
+			"id": "131",
 			"label": "Grave Bolt",
 			"levels3d": {
 				"type": "projectile",
@@ -29503,7 +29910,7 @@
 			}
 		},
 		{
-			"id": "130",
+			"id": "132",
 			"label": "Grenade",
 			"levels3d": {
 				"enable": true,
@@ -29739,7 +30146,7 @@
 			}
 		},
 		{
-			"id": "131",
+			"id": "133",
 			"label": "Grenade Launcher",
 			"levels3d": {
 				"enable": true,
@@ -29976,7 +30383,7 @@
 			}
 		},
 		{
-			"id": "132",
+			"id": "134",
 			"label": "Guiding Bolt",
 			"levels3d": {
 				"type": "explosion",
@@ -30180,7 +30587,7 @@
 			}
 		},
 		{
-			"id": "133",
+			"id": "135",
 			"label": "Gun",
 			"levels3d": {
 				"enable": true,
@@ -30416,7 +30823,7 @@
 			}
 		},
 		{
-			"id": "134",
+			"id": "136",
 			"label": "Holy Water",
 			"levels3d": {
 				"type": "explosion",
@@ -30620,7 +31027,7 @@
 			}
 		},
 		{
-			"id": "135",
+			"id": "137",
 			"label": "Hurl Flame",
 			"levels3d": {
 				"type": "projectile",
@@ -30829,7 +31236,7 @@
 			}
 		},
 		{
-			"id": "136",
+			"id": "138",
 			"label": "Ice Knife",
 			"levels3d": {
 				"type": "explosion",
@@ -31032,7 +31439,7 @@
 			}
 		},
 		{
-			"id": "137",
+			"id": "139",
 			"label": "Javelin",
 			"levels3d": {
 				"type": "explosion",
@@ -31235,7 +31642,212 @@
 			}
 		},
 		{
-			"id": "138",
+			"id": "140",
+			"label": "Jim's Glowing Coin",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "sling",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 1000,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0.75,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": true,
+					"tintColor": "#FFD700",
+					"zIndex": 1,
+					"randomOffset": true,
+					"reverse": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Jim's Glowing Coin",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "141",
 			"label": "Kunai",
 			"levels3d": {
 				"enable": true,
@@ -31472,7 +32084,7 @@
 			}
 		},
 		{
-			"id": "139",
+			"id": "142",
 			"label": "Laser",
 			"levels3d": {
 				"type": "explosion",
@@ -31675,7 +32287,7 @@
 			}
 		},
 		{
-			"id": "140",
+			"id": "143",
 			"label": "Life Drain",
 			"levels3d": {
 				"type": "blackdart",
@@ -31882,7 +32494,7 @@
 			}
 		},
 		{
-			"id": "141",
+			"id": "144",
 			"label": "Life Transference",
 			"levels3d": {
 				"enable": true,
@@ -32119,7 +32731,210 @@
 			}
 		},
 		{
-			"id": "142",
+			"id": "145",
+			"label": "Lightning Launcher",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "chainlightning",
+					"variant": "primary",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Lightning/lightning-impact-6.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Lightning Launcher",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "146",
 			"label": "Lightning Lure",
 			"levels3d": {
 				"enable": true,
@@ -32360,7 +33175,7 @@
 			}
 		},
 		{
-			"id": "143",
+			"id": "147",
 			"label": "Longbow",
 			"levels3d": {
 				"type": "explosion",
@@ -32563,7 +33378,7 @@
 			}
 		},
 		{
-			"id": "144",
+			"id": "148",
 			"label": "Magic Missile",
 			"levels3d": {
 				"enable": true,
@@ -32802,7 +33617,7 @@
 			}
 		},
 		{
-			"id": "145",
+			"id": "149",
 			"label": "Magic Stone",
 			"levels3d": {
 				"enable": true,
@@ -33040,7 +33855,7 @@
 			}
 		},
 		{
-			"id": "146",
+			"id": "150",
 			"label": "Malice",
 			"levels3d": {
 				"type": "explosion",
@@ -33244,7 +34059,7 @@
 			}
 		},
 		{
-			"id": "147",
+			"id": "151",
 			"label": "Maze",
 			"levels3d": {
 				"enable": true,
@@ -33479,7 +34294,7 @@
 			}
 		},
 		{
-			"id": "148",
+			"id": "152",
 			"label": "Message",
 			"levels3d": {
 				"type": "explosion",
@@ -33682,7 +34497,7 @@
 			}
 		},
 		{
-			"id": "149",
+			"id": "153",
 			"label": "Mind Sliver",
 			"levels3d": {
 				"type": "explosion",
@@ -33885,7 +34700,7 @@
 			}
 		},
 		{
-			"id": "150",
+			"id": "154",
 			"label": "Mind Spike",
 			"levels3d": {
 				"enable": true,
@@ -34121,7 +34936,7 @@
 			}
 		},
 		{
-			"id": "151",
+			"id": "155",
 			"label": "Missile",
 			"levels3d": {
 				"type": "explosion",
@@ -34325,7 +35140,7 @@
 			}
 		},
 		{
-			"id": "152",
+			"id": "156",
 			"label": "Modify Memory",
 			"levels3d": {
 				"type": "explosion",
@@ -34530,7 +35345,7 @@
 			}
 		},
 		{
-			"id": "153",
+			"id": "157",
 			"label": "Musket",
 			"levels3d": {
 				"type": "explosion",
@@ -34733,7 +35548,7 @@
 			}
 		},
 		{
-			"id": "154",
+			"id": "158",
 			"label": "Negative Energy Flood",
 			"levels3d": {
 				"type": "explosion",
@@ -34936,7 +35751,7 @@
 			}
 		},
 		{
-			"id": "155",
+			"id": "159",
 			"label": "Pistol",
 			"levels3d": {
 				"type": "explosion",
@@ -35139,7 +35954,7 @@
 			}
 		},
 		{
-			"id": "156",
+			"id": "160",
 			"label": "Planar Binding",
 			"levels3d": {
 				"type": "explosion",
@@ -35343,7 +36158,7 @@
 			}
 		},
 		{
-			"id": "157",
+			"id": "161",
 			"label": "Poison Spray",
 			"levels3d": {
 				"type": "explosion",
@@ -35546,7 +36361,7 @@
 			}
 		},
 		{
-			"id": "158",
+			"id": "162",
 			"label": "Produce Flame",
 			"levels3d": {
 				"type": "explosion",
@@ -35750,7 +36565,7 @@
 			}
 		},
 		{
-			"id": "159",
+			"id": "163",
 			"label": "Psychic Scream",
 			"levels3d": {
 				"type": "explosion",
@@ -35953,7 +36768,7 @@
 			}
 		},
 		{
-			"id": "160",
+			"id": "164",
 			"label": "Ray",
 			"levels3d": {
 				"type": "runicray",
@@ -36162,7 +36977,7 @@
 			}
 		},
 		{
-			"id": "161",
+			"id": "165",
 			"label": "Ray of Enfeeblement",
 			"levels3d": {
 				"enable": true,
@@ -36401,7 +37216,7 @@
 			}
 		},
 		{
-			"id": "162",
+			"id": "166",
 			"label": "Ray of Frost",
 			"levels3d": {
 				"type": "explosion",
@@ -36604,7 +37419,7 @@
 			}
 		},
 		{
-			"id": "163",
+			"id": "167",
 			"label": "Ray of Sickness",
 			"levels3d": {
 				"enable": true,
@@ -36838,7 +37653,7 @@
 			}
 		},
 		{
-			"id": "164",
+			"id": "168",
 			"label": "Rend Mind",
 			"levels3d": {
 				"type": "explosion",
@@ -37041,7 +37856,7 @@
 			}
 		},
 		{
-			"id": "165",
+			"id": "169",
 			"label": "Restore Balance",
 			"levels3d": {
 				"type": "explosion",
@@ -37244,7 +38059,7 @@
 			}
 		},
 		{
-			"id": "166",
+			"id": "170",
 			"label": "Revolver",
 			"levels3d": {
 				"type": "explosion",
@@ -37447,7 +38262,7 @@
 			}
 		},
 		{
-			"id": "167",
+			"id": "171",
 			"label": "Rifle",
 			"levels3d": {
 				"type": "explosion",
@@ -37650,7 +38465,7 @@
 			}
 		},
 		{
-			"id": "168",
+			"id": "172",
 			"label": "Rock",
 			"levels3d": {
 				"enable": true,
@@ -37884,7 +38699,7 @@
 			}
 		},
 		{
-			"id": "169",
+			"id": "173",
 			"label": "Scorching Ray",
 			"levels3d": {
 				"enable": true,
@@ -38128,7 +38943,7 @@
 			}
 		},
 		{
-			"id": "170",
+			"id": "174",
 			"label": "Shocking Grasp",
 			"levels3d": {
 				"type": "explosion",
@@ -38331,7 +39146,7 @@
 			}
 		},
 		{
-			"id": "171",
+			"id": "175",
 			"label": "Shortbow",
 			"levels3d": {
 				"type": "explosion",
@@ -38534,7 +39349,7 @@
 			}
 		},
 		{
-			"id": "172",
+			"id": "176",
 			"label": "Shotgun",
 			"levels3d": {
 				"type": "explosion",
@@ -38737,7 +39552,7 @@
 			}
 		},
 		{
-			"id": "173",
+			"id": "177",
 			"label": "Shuriken",
 			"levels3d": {
 				"type": "explosion",
@@ -38940,7 +39755,7 @@
 			}
 		},
 		{
-			"id": "174",
+			"id": "178",
 			"label": "Siege Boulder",
 			"levels3d": {
 				"enable": true,
@@ -39175,7 +39990,7 @@
 			}
 		},
 		{
-			"id": "175",
+			"id": "179",
 			"label": "Sling",
 			"levels3d": {
 				"type": "explosion",
@@ -39378,7 +40193,7 @@
 			}
 		},
 		{
-			"id": "176",
+			"id": "180",
 			"label": "Smoke Grenade",
 			"levels3d": {
 				"enable": true,
@@ -39615,7 +40430,7 @@
 			}
 		},
 		{
-			"id": "177",
+			"id": "181",
 			"label": "Snow Ball",
 			"levels3d": {
 				"type": "explosion",
@@ -39818,7 +40633,7 @@
 			}
 		},
 		{
-			"id": "178",
+			"id": "182",
 			"label": "Sorcerous Burst",
 			"levels3d": {
 				"type": "explosion",
@@ -40021,7 +40836,7 @@
 			}
 		},
 		{
-			"id": "179",
+			"id": "183",
 			"label": "Soul Cage",
 			"levels3d": {
 				"type": "explosion",
@@ -40229,7 +41044,7 @@
 			}
 		},
 		{
-			"id": "180",
+			"id": "184",
 			"label": "Starry Wisp",
 			"levels3d": {
 				"type": "explosion",
@@ -40433,7 +41248,7 @@
 			}
 		},
 		{
-			"id": "181",
+			"id": "185",
 			"label": "Sun Blade",
 			"levels3d": {
 				"enable": true,
@@ -40669,7 +41484,7 @@
 			}
 		},
 		{
-			"id": "182",
+			"id": "186",
 			"label": "Tasha's Mind Whip",
 			"levels3d": {
 				"enable": true,
@@ -40906,7 +41721,7 @@
 			}
 		},
 		{
-			"id": "183",
+			"id": "187",
 			"label": "Telepathic Bond",
 			"levels3d": {
 				"enable": true,
@@ -41145,7 +41960,7 @@
 			}
 		},
 		{
-			"id": "184",
+			"id": "188",
 			"label": "Telepathic Speech",
 			"levels3d": {
 				"type": "explosion",
@@ -41348,7 +42163,210 @@
 			}
 		},
 		{
-			"id": "185",
+			"id": "189",
+			"label": "Thunder Gauntlet",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "range",
+			"primary": {
+				"video": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "chainlightning",
+					"variant": "primary",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Lightning/lightning-impact-6.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isReturning": false,
+					"isWait": false,
+					"onlyX": false,
+					"opacity": 1,
+					"playbackRate": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Thunder Gauntlet",
+				"menu": "range",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "190",
 			"label": "Witch Bolt",
 			"levels3d": {
 				"type": "runicray",
@@ -41564,1024 +42582,6 @@
 				"name": "5e Animations",
 				"moduleVersion": "2.0.0",
 				"version": 1686753301417
-			}
-		},
-		{
-			"id": "186",
-			"label": "Antagonize",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "range",
-			"primary": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "arrow",
-					"variant": "regular",
-					"color": "regular",
-					"enableCustom": true,
-					"customPath": "jb2a.spell_projectile.sound.01.pinkteal"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-4.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 800,
-					"isReturning": false,
-					"isWait": false,
-					"onlyX": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.condition.curse.01.007.purple"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "psfx.cantrips.mind-sliver.v1",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.5
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 1000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Antagonize",
-				"menu": "range",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "187",
-			"label": "Force Ballista",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "range",
-			"primary": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "spell",
-					"animation": "eldritchblast",
-					"variant": "01",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "psfx.cantrips.eldritch-blast.v1",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isReturning": false,
-					"isWait": false,
-					"onlyX": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Force Ballista",
-				"menu": "range",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "188",
-			"label": "Jim's Glowing Coin",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "range",
-			"primary": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "sling",
-					"variant": "01",
-					"color": "white",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 1000,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-3.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0.75,
-					"delay": 0,
-					"elevation": 1000,
-					"isReturning": false,
-					"isWait": false,
-					"onlyX": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"tint": true,
-					"tintColor": "#FFD700",
-					"zIndex": 1,
-					"randomOffset": true,
-					"reverse": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Jim's Glowing Coin",
-				"menu": "range",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "189",
-			"label": "Lightning Launcher",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "range",
-			"primary": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "spell",
-					"animation": "chainlightning",
-					"variant": "primary",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Lightning/lightning-impact-6.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isReturning": false,
-					"isWait": false,
-					"onlyX": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Lightning Launcher",
-				"menu": "range",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "190",
-			"label": "Thunder Gauntlet",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "range",
-			"primary": {
-				"video": {
-					"dbSection": "range",
-					"menuType": "spell",
-					"animation": "chainlightning",
-					"variant": "primary",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Lightning/lightning-impact-6.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isReturning": false,
-					"isWait": false,
-					"onlyX": false,
-					"opacity": 1,
-					"playbackRate": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Thunder Gauntlet",
-				"menu": "range",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
 			}
 		}
 	],
@@ -42801,6 +42801,218 @@
 		},
 		{
 			"id": "192",
+			"label": "Absorb Elements",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_attack.01.multicolored01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.25,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Elements",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "193",
 			"label": "Acid (vial)",
 			"levels3d": {
 				"type": "explosion",
@@ -43013,7 +43225,7 @@
 			}
 		},
 		{
-			"id": "193",
+			"id": "194",
 			"label": "Action Surge",
 			"levels3d": {
 				"enable": true,
@@ -43242,7 +43454,7 @@
 			}
 		},
 		{
-			"id": "194",
+			"id": "195",
 			"label": "Adrenaline Rush",
 			"levels3d": {
 				"enable": true,
@@ -43471,7 +43683,7 @@
 			}
 		},
 		{
-			"id": "195",
+			"id": "196",
 			"label": "Aid",
 			"levels3d": {
 				"enable": true,
@@ -43694,7 +43906,7 @@
 			}
 		},
 		{
-			"id": "196",
+			"id": "197",
 			"label": "Air Bubble",
 			"levels3d": {
 				"type": "explosion",
@@ -43908,7 +44120,7 @@
 			}
 		},
 		{
-			"id": "197",
+			"id": "198",
 			"label": "Alter Self",
 			"levels3d": {
 				"enable": true,
@@ -44127,7 +44339,7 @@
 			}
 		},
 		{
-			"id": "198",
+			"id": "199",
 			"label": "Animal Friendship",
 			"levels3d": {
 				"enable": true,
@@ -44359,7 +44571,7 @@
 			}
 		},
 		{
-			"id": "199",
+			"id": "200",
 			"label": "Animal Messenger",
 			"levels3d": {
 				"enable": true,
@@ -44577,7 +44789,7 @@
 			}
 		},
 		{
-			"id": "200",
+			"id": "201",
 			"label": "Animal Shapes",
 			"levels3d": {
 				"type": "castingsign",
@@ -44791,7 +45003,7 @@
 			}
 		},
 		{
-			"id": "201",
+			"id": "202",
 			"label": "Animate Dead",
 			"levels3d": {
 				"enable": true,
@@ -45011,7 +45223,7 @@
 			}
 		},
 		{
-			"id": "202",
+			"id": "203",
 			"label": "Animate Objects",
 			"levels3d": {
 				"enable": true,
@@ -45231,7 +45443,219 @@
 			}
 		},
 		{
-			"id": "203",
+			"id": "204",
+			"label": "Arcane Armor",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "complete",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.magic_signs.rune.02.complete"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Arcane Armor",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "205",
 			"label": "Arcane Eye",
 			"levels3d": {
 				"enable": true,
@@ -45455,7 +45879,7 @@
 			}
 		},
 		{
-			"id": "204",
+			"id": "206",
 			"label": "Arcane Gate",
 			"levels3d": {
 				"enable": true,
@@ -45677,7 +46101,7 @@
 			}
 		},
 		{
-			"id": "205",
+			"id": "207",
 			"label": "Arcane Hand",
 			"levels3d": {
 				"enable": true,
@@ -45905,7 +46329,219 @@
 			}
 		},
 		{
-			"id": "206",
+			"id": "208",
+			"label": "Arcane Jolt",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "energystrand",
+					"variant": "01",
+					"color": "blueorange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Arcane Jolt",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "209",
 			"label": "Arcane Lock",
 			"levels3d": {
 				"enable": true,
@@ -46121,7 +46757,7 @@
 			}
 		},
 		{
-			"id": "207",
+			"id": "210",
 			"label": "Arcane Recovery",
 			"levels3d": {
 				"enable": true,
@@ -46352,7 +46988,7 @@
 			}
 		},
 		{
-			"id": "208",
+			"id": "211",
 			"label": "Arcane Sword",
 			"levels3d": {
 				"type": "explosion",
@@ -46564,7 +47200,7 @@
 			}
 		},
 		{
-			"id": "209",
+			"id": "212",
 			"label": "Arcane Vigor",
 			"levels3d": {
 				"type": "explosion",
@@ -46777,7 +47413,7 @@
 			}
 		},
 		{
-			"id": "210",
+			"id": "213",
 			"label": "Arcane Ward",
 			"levels3d": {
 				"type": "explosion",
@@ -46989,7 +47625,219 @@
 			}
 		},
 		{
-			"id": "211",
+			"id": "214",
+			"label": "Armor Model",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "complete",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.magic_signs.rune.02.complete"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Armor Model",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "215",
 			"label": "Armor of Agathys",
 			"levels3d": {
 				"enable": true,
@@ -47212,7 +48060,7 @@
 			}
 		},
 		{
-			"id": "212",
+			"id": "216",
 			"levels3d": {
 				"type": "explosion",
 				"data": {
@@ -47424,7 +48272,7 @@
 			}
 		},
 		{
-			"id": "213",
+			"id": "217",
 			"label": "Ashardalon's Stride",
 			"levels3d": {
 				"type": "explosion",
@@ -47638,7 +48486,7 @@
 			}
 		},
 		{
-			"id": "214",
+			"id": "218",
 			"label": "Assassin's Blood",
 			"levels3d": {
 				"type": "explosion",
@@ -47850,7 +48698,7 @@
 			}
 		},
 		{
-			"id": "215",
+			"id": "219",
 			"label": "Astral Projection",
 			"levels3d": {
 				"enable": true,
@@ -48072,7 +48920,7 @@
 			}
 		},
 		{
-			"id": "216",
+			"id": "220",
 			"label": "Augury",
 			"levels3d": {
 				"enable": true,
@@ -48293,7 +49141,7 @@
 			}
 		},
 		{
-			"id": "217",
+			"id": "221",
 			"label": "Awaken",
 			"levels3d": {
 				"enable": true,
@@ -48513,7 +49361,7 @@
 			}
 		},
 		{
-			"id": "218",
+			"id": "222",
 			"label": "Bane",
 			"levels3d": {
 				"type": "castingsign",
@@ -48742,7 +49590,7 @@
 			}
 		},
 		{
-			"id": "219",
+			"id": "223",
 			"label": "Banishment",
 			"levels3d": {
 				"type": "castingsign",
@@ -48959,7 +49807,7 @@
 			}
 		},
 		{
-			"id": "220",
+			"id": "224",
 			"label": "Bardic Inspiration",
 			"levels3d": {
 				"type": "vortex",
@@ -49179,7 +50027,7 @@
 			}
 		},
 		{
-			"id": "221",
+			"id": "225",
 			"label": "Beacon of Hope",
 			"levels3d": {
 				"enable": true,
@@ -49404,7 +50252,7 @@
 			}
 		},
 		{
-			"id": "222",
+			"id": "226",
 			"label": "Beast Bond",
 			"levels3d": {
 				"enable": true,
@@ -49624,7 +50472,7 @@
 			}
 		},
 		{
-			"id": "223",
+			"id": "227",
 			"label": "Beast Sense",
 			"levels3d": {
 				"enable": true,
@@ -49844,7 +50692,7 @@
 			}
 		},
 		{
-			"id": "224",
+			"id": "228",
 			"label": "Bend Luck",
 			"levels3d": {
 				"type": "explosion",
@@ -50056,7 +50904,7 @@
 			}
 		},
 		{
-			"id": "225",
+			"id": "229",
 			"label": "Bestow Curse",
 			"levels3d": {
 				"enable": true,
@@ -50283,7 +51131,7 @@
 			}
 		},
 		{
-			"id": "226",
+			"id": "230",
 			"label": "Bigby's Hand",
 			"levels3d": {
 				"enable": true,
@@ -50511,7 +51359,7 @@
 			}
 		},
 		{
-			"id": "227",
+			"id": "231",
 			"label": "Bite",
 			"levels3d": {
 				"enable": true,
@@ -50757,7 +51605,7 @@
 			}
 		},
 		{
-			"id": "228",
+			"id": "232",
 			"label": "Blade Barrier",
 			"levels3d": {
 				"type": "explosion",
@@ -50969,7 +51817,7 @@
 			}
 		},
 		{
-			"id": "229",
+			"id": "233",
 			"label": "Blade of Disaster",
 			"levels3d": {
 				"type": "explosion",
@@ -51182,7 +52030,7 @@
 			}
 		},
 		{
-			"id": "230",
+			"id": "234",
 			"label": "Blade Ward",
 			"levels3d": {
 				"type": "castingsign",
@@ -51395,7 +52243,7 @@
 			}
 		},
 		{
-			"id": "231",
+			"id": "235",
 			"label": "Bless",
 			"levels3d": {
 				"type": "castingsign",
@@ -51631,7 +52479,7 @@
 			}
 		},
 		{
-			"id": "232",
+			"id": "236",
 			"label": "Blessed Healer",
 			"levels3d": {
 				"type": "magicburst",
@@ -51848,7 +52696,7 @@
 			}
 		},
 		{
-			"id": "233",
+			"id": "237",
 			"label": "Blessed Strikes",
 			"levels3d": {
 				"enable": true,
@@ -52072,7 +52920,7 @@
 			}
 		},
 		{
-			"id": "234",
+			"id": "238",
 			"label": "Blight",
 			"levels3d": {
 				"type": "castingsign",
@@ -52288,7 +53136,7 @@
 			}
 		},
 		{
-			"id": "235",
+			"id": "239",
 			"label": "Blindness/Deafness",
 			"levels3d": {
 				"enable": true,
@@ -52508,7 +53356,7 @@
 			}
 		},
 		{
-			"id": "236",
+			"id": "240",
 			"label": "Blink",
 			"levels3d": {
 				"enable": true,
@@ -52729,7 +53577,7 @@
 			}
 		},
 		{
-			"id": "237",
+			"id": "241",
 			"label": "Booming Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -52944,7 +53792,7 @@
 			}
 		},
 		{
-			"id": "238",
+			"id": "242",
 			"label": "Borrowed Knowledge",
 			"levels3d": {
 				"type": "explosion",
@@ -53157,7 +54005,7 @@
 			}
 		},
 		{
-			"id": "239",
+			"id": "243",
 			"label": "Branches of the Tree",
 			"levels3d": {
 				"type": "explosion",
@@ -53371,7 +54219,7 @@
 			}
 		},
 		{
-			"id": "240",
+			"id": "244",
 			"label": "Bubbling Cauldron",
 			"levels3d": {
 				"enable": true,
@@ -53594,7 +54442,7 @@
 			}
 		},
 		{
-			"id": "241",
+			"id": "245",
 			"label": "Bulwark of Force",
 			"levels3d": {
 				"type": "explosion",
@@ -53806,7 +54654,7 @@
 			}
 		},
 		{
-			"id": "242",
+			"id": "246",
 			"label": "Catnap",
 			"levels3d": {
 				"type": "explosion",
@@ -54018,7 +54866,232 @@
 			}
 		},
 		{
-			"id": "243",
+			"id": "247",
+			"label": "Cause Fear",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_13.webp",
+					"color01": "#220070",
+					"color02": "#af76d5",
+					"alpha": 1,
+					"duration": 2500,
+					"life": 400
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.toll_the_dead.purple.skull_smoke",
+						"type": "mysteriouslights",
+						"color01": "#4c00ff",
+						"color02": "#ba9fd5",
+						"onCenter": true,
+						"rate": 15,
+						"alpha": 1,
+						"duration": 2200
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": true,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "ui",
+					"variant": "horror",
+					"color": "darkteal",
+					"enableCustom": true,
+					"customPath": "jb2a.condition.curse.01.011.green"
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-2.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Cause Fear",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "248",
 			"label": "Celestial Resilience",
 			"levels3d": {
 				"type": "explosion",
@@ -54230,7 +55303,7 @@
 			}
 		},
 		{
-			"id": "244",
+			"id": "249",
 			"label": "Celestial Revelation",
 			"levels3d": {
 				"type": "explosion",
@@ -54444,7 +55517,7 @@
 			}
 		},
 		{
-			"id": "245",
+			"id": "250",
 			"label": "Ceremony",
 			"levels3d": {
 				"type": "explosion",
@@ -54656,7 +55729,7 @@
 			}
 		},
 		{
-			"id": "246",
+			"id": "251",
 			"label": "Channel Divinity",
 			"levels3d": {
 				"type": "explosion",
@@ -54869,7 +55942,7 @@
 			}
 		},
 		{
-			"id": "247",
+			"id": "252",
 			"label": "Charm",
 			"levels3d": {
 				"type": "castingsign",
@@ -55085,7 +56158,7 @@
 			}
 		},
 		{
-			"id": "248",
+			"id": "253",
 			"label": "Charm Monster",
 			"levels3d": {
 				"type": "castingsign",
@@ -55304,7 +56377,7 @@
 			}
 		},
 		{
-			"id": "249",
+			"id": "254",
 			"label": "Charm Person",
 			"levels3d": {
 				"enable": true,
@@ -55527,7 +56600,7 @@
 			}
 		},
 		{
-			"id": "250",
+			"id": "255",
 			"label": "Children of the Night",
 			"levels3d": {
 				"type": "magicsphere",
@@ -55740,7 +56813,7 @@
 			}
 		},
 		{
-			"id": "251",
+			"id": "256",
 			"label": "Chill Touch",
 			"levels3d": {
 				"type": "explosion",
@@ -55952,7 +57025,7 @@
 			}
 		},
 		{
-			"id": "252",
+			"id": "257",
 			"label": "Clairvoyance",
 			"levels3d": {
 				"enable": true,
@@ -56177,7 +57250,7 @@
 			}
 		},
 		{
-			"id": "253",
+			"id": "258",
 			"label": "Clairvoyant Combatant",
 			"levels3d": {
 				"type": "explosion",
@@ -56389,7 +57462,7 @@
 			}
 		},
 		{
-			"id": "254",
+			"id": "259",
 			"label": "Cleansing Touch",
 			"levels3d": {
 				"enable": true,
@@ -56614,7 +57687,7 @@
 			}
 		},
 		{
-			"id": "255",
+			"id": "260",
 			"label": "Cloak of Shadows",
 			"levels3d": {
 				"type": "explosion",
@@ -56826,7 +57899,7 @@
 			}
 		},
 		{
-			"id": "256",
+			"id": "261",
 			"label": "Clone",
 			"levels3d": {
 				"type": "explosion",
@@ -57039,7 +58112,7 @@
 			}
 		},
 		{
-			"id": "257",
+			"id": "262",
 			"label": "Command",
 			"levels3d": {
 				"enable": true,
@@ -57289,7 +58362,7 @@
 			}
 		},
 		{
-			"id": "258",
+			"id": "263",
 			"label": "Commune",
 			"levels3d": {
 				"enable": true,
@@ -57508,7 +58581,7 @@
 			}
 		},
 		{
-			"id": "259",
+			"id": "264",
 			"label": "Commune with Nature",
 			"levels3d": {
 				"type": "castingsign",
@@ -57724,7 +58797,7 @@
 			}
 		},
 		{
-			"id": "260",
+			"id": "265",
 			"label": "Compelled Duel",
 			"levels3d": {
 				"enable": true,
@@ -57947,7 +59020,7 @@
 			}
 		},
 		{
-			"id": "261",
+			"id": "266",
 			"label": "Comprehend Languages",
 			"levels3d": {
 				"enable": true,
@@ -58168,7 +59241,7 @@
 			}
 		},
 		{
-			"id": "262",
+			"id": "267",
 			"label": "Compulsion",
 			"levels3d": {
 				"type": "castingsign",
@@ -58382,7 +59455,7 @@
 			}
 		},
 		{
-			"id": "263",
+			"id": "268",
 			"label": "Confusion",
 			"levels3d": {
 				"enable": true,
@@ -58598,7 +59671,7 @@
 			}
 		},
 		{
-			"id": "264",
+			"id": "269",
 			"label": "Conjure Animals",
 			"levels3d": {
 				"enable": true,
@@ -58818,7 +59891,7 @@
 			}
 		},
 		{
-			"id": "265",
+			"id": "270",
 			"label": "Conjure Elemental",
 			"levels3d": {
 				"enable": true,
@@ -59038,7 +60111,7 @@
 			}
 		},
 		{
-			"id": "266",
+			"id": "271",
 			"label": "Conjure Fey",
 			"levels3d": {
 				"enable": true,
@@ -59258,7 +60331,7 @@
 			}
 		},
 		{
-			"id": "267",
+			"id": "272",
 			"label": "Constrict",
 			"levels3d": {
 				"enable": true,
@@ -59471,7 +60544,7 @@
 			}
 		},
 		{
-			"id": "268",
+			"id": "273",
 			"label": "Contact Other Plane",
 			"levels3d": {
 				"type": "castingsign",
@@ -59684,7 +60757,7 @@
 			}
 		},
 		{
-			"id": "269",
+			"id": "274",
 			"label": "Contingency",
 			"levels3d": {
 				"type": "castingsign",
@@ -59902,7 +60975,7 @@
 			}
 		},
 		{
-			"id": "270",
+			"id": "275",
 			"label": "Continual Flame",
 			"levels3d": {
 				"enable": true,
@@ -60120,7 +61193,7 @@
 			}
 		},
 		{
-			"id": "271",
+			"id": "276",
 			"label": "Control",
 			"levels3d": {
 				"type": "explosion",
@@ -60332,7 +61405,7 @@
 			}
 		},
 		{
-			"id": "272",
+			"id": "277",
 			"label": "Control Weather",
 			"levels3d": {
 				"type": "explosion",
@@ -60545,7 +61618,7 @@
 			}
 		},
 		{
-			"id": "273",
+			"id": "278",
 			"label": "Controlled Chaos",
 			"levels3d": {
 				"type": "explosion",
@@ -60757,7 +61830,7 @@
 			}
 		},
 		{
-			"id": "274",
+			"id": "279",
 			"label": "Cordon of Arrows",
 			"levels3d": {
 				"type": "castingsign",
@@ -60971,7 +62044,7 @@
 			}
 		},
 		{
-			"id": "275",
+			"id": "280",
 			"label": "Cosmic Omen",
 			"levels3d": {
 				"type": "explosion",
@@ -61183,7 +62256,7 @@
 			}
 		},
 		{
-			"id": "276",
+			"id": "281",
 			"label": "Countercharm",
 			"levels3d": {
 				"enable": true,
@@ -61402,7 +62475,7 @@
 			}
 		},
 		{
-			"id": "277",
+			"id": "282",
 			"label": "Counterspell",
 			"levels3d": {
 				"enable": true,
@@ -61624,7 +62697,7 @@
 			}
 		},
 		{
-			"id": "278",
+			"id": "283",
 			"label": "Crawler Mucus",
 			"levels3d": {
 				"type": "explosion",
@@ -61836,7 +62909,7 @@
 			}
 		},
 		{
-			"id": "279",
+			"id": "284",
 			"label": "Create Food and Water",
 			"levels3d": {
 				"enable": true,
@@ -62057,7 +63130,7 @@
 			}
 		},
 		{
-			"id": "280",
+			"id": "285",
 			"label": "Create Homunculus",
 			"levels3d": {
 				"type": "explosion",
@@ -62270,7 +63343,220 @@
 			}
 		},
 		{
-			"id": "281",
+			"id": "286",
+			"label": "Create Magen",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 500,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_generic.slashing.two_handed"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/slashing-blood-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Create Magen",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "287",
 			"label": "Create Spelljamming Helm",
 			"levels3d": {
 				"type": "explosion",
@@ -62483,7 +63769,7 @@
 			}
 		},
 		{
-			"id": "282",
+			"id": "288",
 			"label": "Create Undead",
 			"levels3d": {
 				"type": "castingsign",
@@ -62698,7 +63984,7 @@
 			}
 		},
 		{
-			"id": "283",
+			"id": "289",
 			"label": "Crown of Stars",
 			"levels3d": {
 				"type": "explosion",
@@ -62911,7 +64197,7 @@
 			}
 		},
 		{
-			"id": "284",
+			"id": "290",
 			"label": "Cunning Action",
 			"levels3d": {
 				"type": "explosion",
@@ -63123,7 +64409,7 @@
 			}
 		},
 		{
-			"id": "285",
+			"id": "291",
 			"label": "Cunning Strike",
 			"levels3d": {
 				"type": "explosion",
@@ -63335,7 +64621,7 @@
 			}
 		},
 		{
-			"id": "286",
+			"id": "292",
 			"label": "Cure Wounds",
 			"levels3d": {
 				"enable": true,
@@ -63590,7 +64876,7 @@
 			}
 		},
 		{
-			"id": "287",
+			"id": "293",
 			"label": "Cutting Words",
 			"levels3d": {
 				"type": "explosion",
@@ -63803,7 +65089,7 @@
 			}
 		},
 		{
-			"id": "288",
+			"id": "294",
 			"label": "Dancing Lights",
 			"levels3d": {
 				"type": "explosion",
@@ -64015,7 +65301,7 @@
 			}
 		},
 		{
-			"id": "289",
+			"id": "295",
 			"label": "Dark One's Blessing",
 			"levels3d": {
 				"type": "explosion",
@@ -64227,7 +65513,7 @@
 			}
 		},
 		{
-			"id": "290",
+			"id": "296",
 			"label": "Dark One's Own Luck",
 			"levels3d": {
 				"type": "explosion",
@@ -64441,7 +65727,7 @@
 			}
 		},
 		{
-			"id": "291",
+			"id": "297",
 			"label": "Darkvision",
 			"levels3d": {
 				"enable": true,
@@ -64664,7 +65950,7 @@
 			}
 		},
 		{
-			"id": "292",
+			"id": "298",
 			"label": "Death Strike",
 			"levels3d": {
 				"type": "explosion",
@@ -64878,7 +66164,7 @@
 			}
 		},
 		{
-			"id": "293",
+			"id": "299",
 			"label": "Death Ward",
 			"levels3d": {
 				"enable": true,
@@ -65096,7 +66382,7 @@
 			}
 		},
 		{
-			"id": "294",
+			"id": "300",
 			"label": "Defense Roll",
 			"levels3d": {
 				"type": "magicsphere",
@@ -65311,7 +66597,220 @@
 			}
 		},
 		{
-			"id": "295",
+			"id": "301",
+			"label": "Defensive Field",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldspell",
+					"animation": "complete",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-barrier-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"saturation": -1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Defensive Field",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "302",
 			"label": "Defensive Tactics",
 			"levels3d": {
 				"type": "explosion",
@@ -65523,7 +67022,7 @@
 			}
 		},
 		{
-			"id": "296",
+			"id": "303",
 			"label": "Deflect Missiles",
 			"levels3d": {
 				"type": "explosion",
@@ -65755,7 +67254,7 @@
 			}
 		},
 		{
-			"id": "297",
+			"id": "304",
 			"label": "Demiplane",
 			"levels3d": {
 				"enable": true,
@@ -65977,7 +67476,7 @@
 			}
 		},
 		{
-			"id": "298",
+			"id": "305",
 			"label": "Detect Thoughts",
 			"levels3d": {
 				"enable": true,
@@ -66195,7 +67694,7 @@
 			}
 		},
 		{
-			"id": "299",
+			"id": "306",
 			"label": "Devious Strikes",
 			"levels3d": {
 				"type": "explosion",
@@ -66407,7 +67906,7 @@
 			}
 		},
 		{
-			"id": "300",
+			"id": "307",
 			"label": "Disciplined Survivor",
 			"levels3d": {
 				"type": "explosion",
@@ -66619,7 +68118,7 @@
 			}
 		},
 		{
-			"id": "301",
+			"id": "308",
 			"label": "Disguise Self",
 			"levels3d": {
 				"enable": true,
@@ -66841,7 +68340,7 @@
 			}
 		},
 		{
-			"id": "302",
+			"id": "309",
 			"label": "Dispel Evil and Good",
 			"levels3d": {
 				"type": "castingsign",
@@ -67053,7 +68552,7 @@
 			}
 		},
 		{
-			"id": "303",
+			"id": "310",
 			"label": "Dispel Magic",
 			"levels3d": {
 				"enable": true,
@@ -67272,7 +68771,7 @@
 			}
 		},
 		{
-			"id": "304",
+			"id": "311",
 			"label": "Dissonant Whispers",
 			"levels3d": {
 				"enable": true,
@@ -67500,7 +68999,7 @@
 			}
 		},
 		{
-			"id": "305",
+			"id": "312",
 			"label": "Divination",
 			"levels3d": {
 				"enable": true,
@@ -67729,7 +69228,7 @@
 			}
 		},
 		{
-			"id": "306",
+			"id": "313",
 			"label": "Divine Favor",
 			"levels3d": {
 				"enable": true,
@@ -67954,7 +69453,7 @@
 			}
 		},
 		{
-			"id": "307",
+			"id": "314",
 			"label": "Divine Intervention",
 			"levels3d": {
 				"enable": true,
@@ -68175,7 +69674,7 @@
 			}
 		},
 		{
-			"id": "308",
+			"id": "315",
 			"label": "Divine Sense",
 			"levels3d": {
 				"type": "explosion",
@@ -68387,7 +69886,7 @@
 			}
 		},
 		{
-			"id": "309",
+			"id": "316",
 			"label": "Divine Smite",
 			"levels3d": {
 				"enable": true,
@@ -68608,7 +70107,7 @@
 			}
 		},
 		{
-			"id": "310",
+			"id": "317",
 			"label": "Divine Strike",
 			"levels3d": {
 				"enable": true,
@@ -68833,7 +70332,7 @@
 			}
 		},
 		{
-			"id": "311",
+			"id": "318",
 			"label": "Divine Word",
 			"levels3d": {
 				"type": "castingsign",
@@ -69051,7 +70550,7 @@
 			}
 		},
 		{
-			"id": "312",
+			"id": "319",
 			"label": "Dominate Beast",
 			"levels3d": {
 				"enable": true,
@@ -69272,7 +70771,7 @@
 			}
 		},
 		{
-			"id": "313",
+			"id": "320",
 			"label": "Dominate Monster",
 			"levels3d": {
 				"enable": true,
@@ -69493,7 +70992,7 @@
 			}
 		},
 		{
-			"id": "314",
+			"id": "321",
 			"label": "Dominate Person",
 			"levels3d": {
 				"enable": true,
@@ -69714,228 +71213,7 @@
 			}
 		},
 		{
-			"id": "315",
-			"label": "Dominate-disable",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_12.webp",
-					"color01": "#e724f5",
-					"color02": "#b771d1",
-					"alpha": 1,
-					"onCenter": true
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.markers.stun.purple.01",
-						"type": "jb2aexplosion",
-						"color01": "#840fd2",
-						"color02": "#d9c4e3",
-						"alpha": 1,
-						"onCenter": true
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-ticking-1.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": true,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "twirl",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-ticking-1.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "enchantment",
-					"variant": "02",
-					"color": "pink",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 2000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "generic",
-					"animation": "outpulse",
-					"variant": "01",
-					"color": "purplepink",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Dominate-disable",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1686753301417
-			}
-		},
-		{
-			"id": "316",
+			"id": "322",
 			"label": "Draconic Flight",
 			"levels3d": {
 				"type": "explosion",
@@ -70151,7 +71429,7 @@
 			}
 		},
 		{
-			"id": "317",
+			"id": "323",
 			"label": "Dread Ambusher",
 			"levels3d": {
 				"type": "explosion",
@@ -70363,7 +71641,7 @@
 			}
 		},
 		{
-			"id": "318",
+			"id": "324",
 			"label": "Dreadful Strikes",
 			"levels3d": {
 				"type": "explosion",
@@ -70575,7 +71853,7 @@
 			}
 		},
 		{
-			"id": "319",
+			"id": "325",
 			"label": "Dream",
 			"levels3d": {
 				"enable": true,
@@ -70797,7 +72075,7 @@
 			}
 		},
 		{
-			"id": "320",
+			"id": "326",
 			"label": "Dream of the Blue Veil",
 			"levels3d": {
 				"enable": true,
@@ -71019,7 +72297,7 @@
 			}
 		},
 		{
-			"id": "321",
+			"id": "327",
 			"label": "Drow Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -71231,7 +72509,7 @@
 			}
 		},
 		{
-			"id": "322",
+			"id": "328",
 			"label": "Druid Grove",
 			"levels3d": {
 				"type": "explosion",
@@ -71443,7 +72721,7 @@
 			}
 		},
 		{
-			"id": "323",
+			"id": "329",
 			"label": "Druidcraft",
 			"levels3d": {
 				"type": "explosion",
@@ -71655,7 +72933,7 @@
 			}
 		},
 		{
-			"id": "324",
+			"id": "330",
 			"label": "Earth Tremor",
 			"levels3d": {
 				"type": "explosion",
@@ -71869,7 +73147,7 @@
 			}
 		},
 		{
-			"id": "325",
+			"id": "331",
 			"label": "Earthbind",
 			"levels3d": {
 				"type": "explosion",
@@ -72081,7 +73359,7 @@
 			}
 		},
 		{
-			"id": "326",
+			"id": "332",
 			"label": "Earthquake",
 			"levels3d": {
 				"type": "explosion",
@@ -72296,7 +73574,219 @@
 			}
 		},
 		{
-			"id": "327",
+			"id": "333",
+			"label": "Eldritch Cannon",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.hammer.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 600,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Eldritch Cannon",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "334",
 			"label": "Eldritch Master",
 			"levels3d": {
 				"type": "explosion",
@@ -72508,7 +73998,7 @@
 			}
 		},
 		{
-			"id": "328",
+			"id": "335",
 			"label": "Eldritch Smite",
 			"levels3d": {
 				"enable": true,
@@ -72730,7 +74220,7 @@
 			}
 		},
 		{
-			"id": "329",
+			"id": "336",
 			"label": "Elemental Affinity",
 			"levels3d": {
 				"type": "explosion",
@@ -72942,7 +74432,7 @@
 			}
 		},
 		{
-			"id": "330",
+			"id": "337",
 			"label": "Elemental Attunement",
 			"levels3d": {
 				"type": "explosion",
@@ -73154,7 +74644,219 @@
 			}
 		},
 		{
-			"id": "331",
+			"id": "338",
+			"label": "Elemental Bane",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_attack.01.multicolored01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Elemental Bane",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "339",
 			"label": "Elemental Weapon",
 			"levels3d": {
 				"enable": true,
@@ -73373,7 +75075,7 @@
 			}
 		},
 		{
-			"id": "332",
+			"id": "340",
 			"label": "Empowered Evocation",
 			"levels3d": {
 				"type": "explosion",
@@ -73585,7 +75287,7 @@
 			}
 		},
 		{
-			"id": "333",
+			"id": "341",
 			"label": "Empty Body",
 			"levels3d": {
 				"type": "explosion",
@@ -73797,7 +75499,236 @@
 			}
 		},
 		{
-			"id": "334",
+			"id": "342",
+			"label": "Encode Thoughts",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_12.webp",
+					"color01": "#da98ec",
+					"color02": "#0023d1",
+					"duration": 1500,
+					"onCenter": true,
+					"alpha": 1
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.magic_signs.rune.enchantment.complete.purple",
+						"type": "magicsphere",
+						"color01": "#bfedf3",
+						"color02": "#ff00f7",
+						"onCenter": true,
+						"rate": 5,
+						"alpha": 1,
+						"scale": 2,
+						"gravity": 1,
+						"duration": 3500,
+						"life": 1000
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "shake",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"playbackRate": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "enchantment",
+					"variant": "runecomplete",
+					"color": "pink",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_strands.02.marker.bluepurple"
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Encode Thoughts",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "343",
 			"label": "Enhance Ability",
 			"levels3d": {
 				"enable": true,
@@ -74043,7 +75974,7 @@
 			}
 		},
 		{
-			"id": "335",
+			"id": "344",
 			"label": "Enlarge/Reduce",
 			"levels3d": {
 				"type": "castingsign",
@@ -74257,7 +76188,7 @@
 			}
 		},
 		{
-			"id": "336",
+			"id": "345",
 			"label": "Ensnaring Strike",
 			"levels3d": {
 				"enable": true,
@@ -74483,7 +76414,7 @@
 			}
 		},
 		{
-			"id": "337",
+			"id": "346",
 			"label": "Enthrall",
 			"levels3d": {
 				"enable": true,
@@ -74705,7 +76636,7 @@
 			}
 		},
 		{
-			"id": "338",
+			"id": "347",
 			"label": "Envenom Weapons",
 			"levels3d": {
 				"type": "explosion",
@@ -74917,7 +76848,7 @@
 			}
 		},
 		{
-			"id": "339",
+			"id": "348",
 			"label": "Ethereal Sight",
 			"levels3d": {
 				"enable": true,
@@ -75141,7 +77072,7 @@
 			}
 		},
 		{
-			"id": "340",
+			"id": "349",
 			"label": "Etherealness",
 			"levels3d": {
 				"enable": true,
@@ -75360,7 +77291,7 @@
 			}
 		},
 		{
-			"id": "341",
+			"id": "350",
 			"label": "Euphoria Breath",
 			"levels3d": {
 				"type": "directionalfire",
@@ -75572,7 +77503,7 @@
 			}
 		},
 		{
-			"id": "342",
+			"id": "351",
 			"label": "Expeditious Retreat",
 			"levels3d": {
 				"enable": true,
@@ -75825,7 +77756,7 @@
 			}
 		},
 		{
-			"id": "343",
+			"id": "352",
 			"levels3d": {
 				"type": "slash",
 				"data": {
@@ -76038,7 +77969,7 @@
 			}
 		},
 		{
-			"id": "344",
+			"id": "353",
 			"label": "Eyebite",
 			"levels3d": {
 				"type": "castingsign",
@@ -76253,7 +78184,7 @@
 			}
 		},
 		{
-			"id": "345",
+			"id": "354",
 			"label": "Fabricate",
 			"levels3d": {
 				"type": "explosion",
@@ -76466,7 +78397,7 @@
 			}
 		},
 		{
-			"id": "346",
+			"id": "355",
 			"label": "Faithful Hound",
 			"levels3d": {
 				"enable": true,
@@ -76689,7 +78620,7 @@
 			}
 		},
 		{
-			"id": "347",
+			"id": "356",
 			"label": "False Life",
 			"levels3d": {
 				"enable": true,
@@ -76912,7 +78843,7 @@
 			}
 		},
 		{
-			"id": "348",
+			"id": "357",
 			"label": "Fast Hands",
 			"levels3d": {
 				"type": "explosion",
@@ -77124,7 +79055,7 @@
 			}
 		},
 		{
-			"id": "349",
+			"id": "358",
 			"label": "Feather Fall",
 			"levels3d": {
 				"enable": true,
@@ -77350,7 +79281,7 @@
 			}
 		},
 		{
-			"id": "350",
+			"id": "359",
 			"label": "Feign Death",
 			"levels3d": {
 				"enable": true,
@@ -77575,7 +79506,7 @@
 			}
 		},
 		{
-			"id": "351",
+			"id": "360",
 			"label": "Find Familiar",
 			"levels3d": {
 				"enable": true,
@@ -77794,7 +79725,7 @@
 			}
 		},
 		{
-			"id": "352",
+			"id": "361",
 			"label": "Find Greater Steed",
 			"levels3d": {
 				"enable": true,
@@ -78013,7 +79944,7 @@
 			}
 		},
 		{
-			"id": "353",
+			"id": "362",
 			"label": "Find Steed",
 			"levels3d": {
 				"enable": true,
@@ -78232,7 +80163,7 @@
 			}
 		},
 		{
-			"id": "354",
+			"id": "363",
 			"label": "Find the Path",
 			"levels3d": {
 				"enable": true,
@@ -78450,7 +80381,7 @@
 			}
 		},
 		{
-			"id": "355",
+			"id": "364",
 			"label": "Find Traps",
 			"levels3d": {
 				"enable": true,
@@ -78670,7 +80601,7 @@
 			}
 		},
 		{
-			"id": "356",
+			"id": "365",
 			"label": "Fire Storm",
 			"levels3d": {
 				"type": "explosion",
@@ -78882,7 +80813,7 @@
 			}
 		},
 		{
-			"id": "357",
+			"id": "366",
 			"label": "Fizban's Platinum Shield",
 			"levels3d": {
 				"type": "explosion",
@@ -79094,7 +81025,7 @@
 			}
 		},
 		{
-			"id": "358",
+			"id": "367",
 			"label": "Flame Arrows",
 			"levels3d": {
 				"enable": true,
@@ -79313,7 +81244,7 @@
 			}
 		},
 		{
-			"id": "359",
+			"id": "368",
 			"label": "Flame Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -79551,7 +81482,236 @@
 			}
 		},
 		{
-			"id": "360",
+			"id": "369",
+			"label": "Flash of Genius",
+			"levels3d": {
+				"enable": true,
+				"type": "magicsphere",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/emberssmall.png",
+					"onCenter": true,
+					"alpha": 1,
+					"color01": "#007517",
+					"color02": "#9b06fe",
+					"rate": 5
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.ui.indicator.green.01.01",
+						"type": "mysteriouslights",
+						"color01": "#dfd007",
+						"color02": "#00fa81",
+						"alpha": 1,
+						"onCenter": true,
+						"rate": 25
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-2.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 800,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": false,
+					"saturation": -1,
+					"contrast": 0.75,
+					"tintColor": "#ffffff"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-1.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "energy",
+					"animation": "dodecahedron",
+					"variant": "rolled",
+					"color": "blue",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 2500,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 0.5,
+					"zIndex": 1,
+					"tint": false,
+					"tintColor": ""
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-3.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "icons/svg/light.svg"
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Flash of Genius",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "370",
 			"label": "Flesh to Stone",
 			"levels3d": {
 				"type": "castingsign",
@@ -79765,7 +81925,7 @@
 			}
 		},
 		{
-			"id": "361",
+			"id": "371",
 			"label": "Floating Disk",
 			"levels3d": {
 				"enable": true,
@@ -79986,7 +82146,7 @@
 			}
 		},
 		{
-			"id": "362",
+			"id": "372",
 			"label": "Fly",
 			"levels3d": {
 				"enable": true,
@@ -80209,7 +82369,7 @@
 			}
 		},
 		{
-			"id": "363",
+			"id": "373",
 			"label": "Flyby",
 			"levels3d": {
 				"type": "slash",
@@ -80425,7 +82585,7 @@
 			}
 		},
 		{
-			"id": "364",
+			"id": "374",
 			"label": "Font of Inspiration",
 			"levels3d": {
 				"type": "explosion",
@@ -80637,7 +82797,7 @@
 			}
 		},
 		{
-			"id": "365",
+			"id": "375",
 			"label": "Font of Magic",
 			"levels3d": {
 				"type": "explosion",
@@ -80849,7 +83009,7 @@
 			}
 		},
 		{
-			"id": "366",
+			"id": "376",
 			"label": "Forbiddance",
 			"levels3d": {
 				"type": "explosion",
@@ -81061,7 +83221,7 @@
 			}
 		},
 		{
-			"id": "367",
+			"id": "377",
 			"label": "Forcecage",
 			"levels3d": {
 				"type": "explosion",
@@ -81274,7 +83434,7 @@
 			}
 		},
 		{
-			"id": "368",
+			"id": "378",
 			"label": "Foresight",
 			"levels3d": {
 				"enable": true,
@@ -81496,7 +83656,7 @@
 			}
 		},
 		{
-			"id": "369",
+			"id": "379",
 			"label": "Freedom of Movement",
 			"levels3d": {
 				"enable": true,
@@ -81715,7 +83875,7 @@
 			}
 		},
 		{
-			"id": "370",
+			"id": "380",
 			"label": "Friends",
 			"levels3d": {
 				"type": "explosion",
@@ -81927,7 +84087,7 @@
 			}
 		},
 		{
-			"id": "371",
+			"id": "381",
 			"label": "Frightful Presence",
 			"levels3d": {
 				"enable": true,
@@ -82151,7 +84311,7 @@
 			}
 		},
 		{
-			"id": "372",
+			"id": "382",
 			"label": "Frostbite",
 			"levels3d": {
 				"enable": true,
@@ -82376,7 +84536,7 @@
 			}
 		},
 		{
-			"id": "373",
+			"id": "383",
 			"label": "Gaseous Form",
 			"levels3d": {
 				"enable": true,
@@ -82599,7 +84759,7 @@
 			}
 		},
 		{
-			"id": "374",
+			"id": "384",
 			"label": "Gate",
 			"levels3d": {
 				"enable": true,
@@ -82821,7 +84981,7 @@
 			}
 		},
 		{
-			"id": "375",
+			"id": "385",
 			"label": "Gaze",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -83036,7 +85196,7 @@
 			}
 		},
 		{
-			"id": "376",
+			"id": "386",
 			"label": "Geas",
 			"levels3d": {
 				"type": "castingsign",
@@ -83252,7 +85412,7 @@
 			}
 		},
 		{
-			"id": "377",
+			"id": "387",
 			"label": "Gentle Repose",
 			"levels3d": {
 				"enable": true,
@@ -83471,7 +85631,7 @@
 			}
 		},
 		{
-			"id": "378",
+			"id": "388",
 			"label": "Giant Insect",
 			"levels3d": {
 				"type": "castingsign",
@@ -83686,7 +85846,219 @@
 			}
 		},
 		{
-			"id": "379",
+			"id": "389",
+			"label": "Gift of Gab",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "outpulse",
+					"variant": "01",
+					"color": "purplepink",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Bardic-Inspiration.ogg",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Gift of Gab",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "390",
 			"label": "Glare",
 			"levels3d": {
 				"type": "projectile",
@@ -83905,7 +86277,7 @@
 			}
 		},
 		{
-			"id": "380",
+			"id": "391",
 			"label": "Glibness",
 			"levels3d": {
 				"type": "explosion",
@@ -84117,7 +86489,7 @@
 			}
 		},
 		{
-			"id": "381",
+			"id": "392",
 			"label": "Glorious Defense",
 			"levels3d": {
 				"type": "explosion",
@@ -84329,7 +86701,7 @@
 			}
 		},
 		{
-			"id": "382",
+			"id": "393",
 			"label": "Glyph of Warding",
 			"levels3d": {
 				"enable": true,
@@ -84548,7 +86920,7 @@
 			}
 		},
 		{
-			"id": "383",
+			"id": "394",
 			"label": "Goodberry",
 			"levels3d": {
 				"enable": true,
@@ -84774,7 +87146,7 @@
 			}
 		},
 		{
-			"id": "384",
+			"id": "395",
 			"label": "Gore",
 			"levels3d": {
 				"enable": true,
@@ -84997,7 +87369,7 @@
 			}
 		},
 		{
-			"id": "385",
+			"id": "396",
 			"label": "Grasping Vine",
 			"levels3d": {
 				"type": "castingsign",
@@ -85212,7 +87584,7 @@
 			}
 		},
 		{
-			"id": "386",
+			"id": "397",
 			"label": "Greater Comprehension",
 			"levels3d": {
 				"enable": true,
@@ -85436,7 +87808,7 @@
 			}
 		},
 		{
-			"id": "387",
+			"id": "398",
 			"label": "Greater Invisibility",
 			"levels3d": {
 				"enable": true,
@@ -85683,7 +88055,7 @@
 			}
 		},
 		{
-			"id": "388",
+			"id": "399",
 			"label": "Greater Restoration",
 			"levels3d": {
 				"enable": true,
@@ -85906,7 +88278,7 @@
 			}
 		},
 		{
-			"id": "389",
+			"id": "400",
 			"label": "Green-Flame Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -86147,7 +88519,7 @@
 			}
 		},
 		{
-			"id": "390",
+			"id": "401",
 			"label": "Guardian of Faith",
 			"levels3d": {
 				"type": "castingsign",
@@ -86362,7 +88734,7 @@
 			}
 		},
 		{
-			"id": "391",
+			"id": "402",
 			"label": "Guardian of Nature",
 			"levels3d": {
 				"type": "explosion",
@@ -86574,7 +88946,7 @@
 			}
 		},
 		{
-			"id": "392",
+			"id": "403",
 			"label": "Guards and Wards",
 			"levels3d": {
 				"type": "explosion",
@@ -86786,7 +89158,7 @@
 			}
 		},
 		{
-			"id": "393",
+			"id": "404",
 			"label": "Guidance",
 			"levels3d": {
 				"type": "explosion",
@@ -86998,7 +89370,7 @@
 			}
 		},
 		{
-			"id": "394",
+			"id": "405",
 			"label": "Gust",
 			"levels3d": {
 				"type": "castingsign",
@@ -87220,7 +89592,7 @@
 			}
 		},
 		{
-			"id": "395",
+			"id": "406",
 			"label": "Hail of Thorns",
 			"levels3d": {
 				"enable": true,
@@ -87445,7 +89817,7 @@
 			}
 		},
 		{
-			"id": "396",
+			"id": "407",
 			"label": "Hand of Harm",
 			"levels3d": {
 				"type": "explosion",
@@ -87657,7 +90029,7 @@
 			}
 		},
 		{
-			"id": "397",
+			"id": "408",
 			"label": "Hand of Healing",
 			"levels3d": {
 				"type": "explosion",
@@ -87869,7 +90241,7 @@
 			}
 		},
 		{
-			"id": "398",
+			"id": "409",
 			"label": "Hand of Ultimate Mercy",
 			"levels3d": {
 				"type": "explosion",
@@ -88082,7 +90454,7 @@
 			}
 		},
 		{
-			"id": "399",
+			"id": "410",
 			"label": "Harm",
 			"levels3d": {
 				"enable": true,
@@ -88313,7 +90685,7 @@
 			}
 		},
 		{
-			"id": "400",
+			"id": "411",
 			"label": "Haste",
 			"levels3d": {
 				"enable": true,
@@ -88535,7 +90907,7 @@
 			}
 		},
 		{
-			"id": "401",
+			"id": "412",
 			"label": "Heal-disabled",
 			"levels3d": {
 				"enable": true,
@@ -88770,7 +91142,7 @@
 			}
 		},
 		{
-			"id": "402",
+			"id": "413",
 			"label": "Healing Hands",
 			"levels3d": {
 				"enable": true,
@@ -88994,7 +91366,7 @@
 			}
 		},
 		{
-			"id": "403",
+			"id": "414",
 			"label": "Healing Light",
 			"levels3d": {
 				"type": "explosion",
@@ -89206,7 +91578,7 @@
 			}
 		},
 		{
-			"id": "404",
+			"id": "415",
 			"label": "Healing Surge",
 			"levels3d": {
 				"enable": true,
@@ -89429,7 +91801,7 @@
 			}
 		},
 		{
-			"id": "405",
+			"id": "416",
 			"label": "Healing Touch",
 			"levels3d": {
 				"type": "explosion",
@@ -89636,7 +92008,7 @@
 			}
 		},
 		{
-			"id": "406",
+			"id": "417",
 			"label": "Healing Word",
 			"levels3d": {
 				"enable": true,
@@ -89887,7 +92259,7 @@
 			}
 		},
 		{
-			"id": "407",
+			"id": "418",
 			"label": "Heat Metal",
 			"levels3d": {
 				"enable": true,
@@ -90109,7 +92481,7 @@
 			}
 		},
 		{
-			"id": "408",
+			"id": "419",
 			"label": "Hellish Rebuke",
 			"levels3d": {
 				"enable": true,
@@ -90332,7 +92704,7 @@
 			}
 		},
 		{
-			"id": "409",
+			"id": "420",
 			"label": "Heroes' Feast",
 			"levels3d": {
 				"enable": true,
@@ -90552,7 +92924,7 @@
 			}
 		},
 		{
-			"id": "410",
+			"id": "421",
 			"label": "Heroism",
 			"levels3d": {
 				"enable": true,
@@ -90775,7 +93147,7 @@
 			}
 		},
 		{
-			"id": "411",
+			"id": "422",
 			"label": "Hex",
 			"levels3d": {
 				"enable": true,
@@ -90999,7 +93371,7 @@
 			}
 		},
 		{
-			"id": "412",
+			"id": "423",
 			"label": "Hide in Plain Sight",
 			"levels3d": {
 				"type": "explosion",
@@ -91211,7 +93583,7 @@
 			}
 		},
 		{
-			"id": "413",
+			"id": "424",
 			"label": "Hideous Laughter",
 			"levels3d": {
 				"enable": true,
@@ -91434,7 +93806,7 @@
 			}
 		},
 		{
-			"id": "414",
+			"id": "425",
 			"label": "Hold Monster",
 			"levels3d": {
 				"enable": true,
@@ -91654,7 +94026,7 @@
 			}
 		},
 		{
-			"id": "415",
+			"id": "426",
 			"label": "Hold Person",
 			"levels3d": {
 				"enable": true,
@@ -91874,7 +94246,7 @@
 			}
 		},
 		{
-			"id": "416",
+			"id": "427",
 			"label": "Holy Nimbus",
 			"levels3d": {
 				"type": "explosion",
@@ -92086,7 +94458,7 @@
 			}
 		},
 		{
-			"id": "417",
+			"id": "428",
 			"label": "Holy Weapon",
 			"levels3d": {
 				"type": "explosion",
@@ -92298,7 +94670,7 @@
 			}
 		},
 		{
-			"id": "418",
+			"id": "429",
 			"label": "Horrifying Visage",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -92513,7 +94885,7 @@
 			}
 		},
 		{
-			"id": "419",
+			"id": "430",
 			"levels3d": {
 				"type": "explosion",
 				"data": {
@@ -92725,7 +95097,7 @@
 			}
 		},
 		{
-			"id": "420",
+			"id": "431",
 			"label": "Hunter's Defense",
 			"levels3d": {
 				"type": "explosion",
@@ -92937,7 +95309,7 @@
 			}
 		},
 		{
-			"id": "421",
+			"id": "432",
 			"label": "Hunter's Mark",
 			"levels3d": {
 				"enable": true,
@@ -93186,7 +95558,7 @@
 			}
 		},
 		{
-			"id": "422",
+			"id": "433",
 			"label": "Hunter's Prey",
 			"levels3d": {
 				"type": "explosion",
@@ -93398,7 +95770,7 @@
 			}
 		},
 		{
-			"id": "423",
+			"id": "434",
 			"label": "Hurl Through Hell",
 			"levels3d": {
 				"type": "explosion",
@@ -93611,7 +95983,7 @@
 			}
 		},
 		{
-			"id": "424",
+			"id": "435",
 			"label": "Identify",
 			"levels3d": {
 				"enable": true,
@@ -93829,7 +96201,7 @@
 			}
 		},
 		{
-			"id": "425",
+			"id": "436",
 			"label": "Illusory Dragon",
 			"levels3d": {
 				"type": "explosion",
@@ -94041,7 +96413,7 @@
 			}
 		},
 		{
-			"id": "426",
+			"id": "437",
 			"label": "Illusory Reality",
 			"levels3d": {
 				"type": "explosion",
@@ -94253,7 +96625,7 @@
 			}
 		},
 		{
-			"id": "427",
+			"id": "438",
 			"label": "Illusory Script",
 			"levels3d": {
 				"enable": true,
@@ -94472,7 +96844,7 @@
 			}
 		},
 		{
-			"id": "428",
+			"id": "439",
 			"label": "Illusory Self",
 			"levels3d": {
 				"enable": true,
@@ -94719,7 +97091,7 @@
 			}
 		},
 		{
-			"id": "429",
+			"id": "440",
 			"label": "Immolation",
 			"levels3d": {
 				"enable": true,
@@ -94943,7 +97315,7 @@
 			}
 		},
 		{
-			"id": "430",
+			"id": "441",
 			"label": "Imprisonment",
 			"levels3d": {
 				"enable": true,
@@ -95162,7 +97534,220 @@
 			}
 		},
 		{
-			"id": "431",
+			"id": "442",
+			"label": "Incite Greed",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.ioun_stones.01.purple.absorption"
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 800,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 3500,
+					"saturate": 0,
+					"size": 0.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "light",
+					"variant": "complete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0.75,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 3,
+					"tint": true,
+					"tintColor": "#a382e7",
+					"zIndex": 1,
+					"saturation": -1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Incite Greed",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "443",
 			"label": "Indomitable",
 			"levels3d": {
 				"type": "explosion",
@@ -95374,7 +97959,7 @@
 			}
 		},
 		{
-			"id": "432",
+			"id": "444",
 			"label": "Infernal Calling",
 			"levels3d": {
 				"enable": true,
@@ -95597,7 +98182,241 @@
 			}
 		},
 		{
-			"id": "433",
+			"id": "445",
+			"label": "Infestation",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
+					"speed": 10,
+					"duration": 2000,
+					"life": 400,
+					"alpha": 1,
+					"onCenter": true,
+					"color01": "#ff9500",
+					"color02": "#beb7b7"
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.butterflies.many.bright_orange",
+						"type": "jb2aexplosionnolight",
+						"speed": 10,
+						"scale": 1,
+						"alpha": 1,
+						"onCenter": true,
+						"color01": "#d2cbcb",
+						"color02": "#dbce0f",
+						"duration": 2500,
+						"life": 400
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": true,
+					"sourceType": "swipe",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "dots",
+					"variant": "03",
+					"color": "green",
+					"enableCustom": true,
+					"customPath": "jb2a.butterflies.many.orange"
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 2000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1.2,
+					"zIndex": 1,
+					"tint": true,
+					"tintColor": "#00ff55"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.butterflies.many.orange"
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1,
+					"playbackRate": 3
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "conjuration",
+					"variant": "runecomplete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 0.75,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"tintColor": "#ae00ff"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.butterflies.many.orange"
+				}
+			},
+			"metaData": {
+				"label": "Infestation",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "446",
 			"label": "Infiltration Expertise",
 			"levels3d": {
 				"type": "explosion",
@@ -95809,7 +98628,7 @@
 			}
 		},
 		{
-			"id": "434",
+			"id": "447",
 			"label": "Inflict Wounds",
 			"levels3d": {
 				"enable": true,
@@ -96033,7 +98852,7 @@
 			}
 		},
 		{
-			"id": "435",
+			"id": "448",
 			"label": "Ink",
 			"levels3d": {
 				"type": "explosion",
@@ -96245,7 +99064,7 @@
 			}
 		},
 		{
-			"id": "436",
+			"id": "449",
 			"label": "Instant Summons",
 			"levels3d": {
 				"enable": true,
@@ -96469,7 +99288,7 @@
 			}
 		},
 		{
-			"id": "437",
+			"id": "450",
 			"label": "Invisibility",
 			"levels3d": {
 				"enable": true,
@@ -96716,7 +99535,7 @@
 			}
 		},
 		{
-			"id": "438",
+			"id": "451",
 			"label": "Invoke Duplicity",
 			"levels3d": {
 				"type": "explosion",
@@ -96928,7 +99747,7 @@
 			}
 		},
 		{
-			"id": "439",
+			"id": "452",
 			"label": "Irresistible Dance",
 			"levels3d": {
 				"enable": true,
@@ -97149,7 +99968,7 @@
 			}
 		},
 		{
-			"id": "440",
+			"id": "453",
 			"label": "Jump",
 			"levels3d": {
 				"enable": true,
@@ -97397,7 +100216,7 @@
 			}
 		},
 		{
-			"id": "441",
+			"id": "454",
 			"label": "Kinetic Jaunt",
 			"levels3d": {
 				"type": "explosion",
@@ -97609,7 +100428,7 @@
 			}
 		},
 		{
-			"id": "442",
+			"id": "455",
 			"label": "Knock",
 			"levels3d": {
 				"enable": true,
@@ -97835,7 +100654,7 @@
 			}
 		},
 		{
-			"id": "443",
+			"id": "456",
 			"label": "Lay on Hands",
 			"levels3d": {
 				"enable": true,
@@ -98059,7 +100878,7 @@
 			}
 		},
 		{
-			"id": "444",
+			"id": "457",
 			"label": "Legend Lore",
 			"levels3d": {
 				"type": "castingsign",
@@ -98273,7 +101092,7 @@
 			}
 		},
 		{
-			"id": "445",
+			"id": "458",
 			"label": "Levitate",
 			"levels3d": {
 				"enable": true,
@@ -98495,7 +101314,7 @@
 			}
 		},
 		{
-			"id": "446",
+			"id": "459",
 			"label": "Light",
 			"levels3d": {
 				"type": "explosion",
@@ -98707,7 +101526,7 @@
 			}
 		},
 		{
-			"id": "447",
+			"id": "460",
 			"label": "Lightning Arrow",
 			"levels3d": {
 				"enable": true,
@@ -98927,7 +101746,7 @@
 			}
 		},
 		{
-			"id": "448",
+			"id": "461",
 			"label": "Locate",
 			"levels3d": {
 				"enable": true,
@@ -99147,7 +101966,7 @@
 			}
 		},
 		{
-			"id": "449",
+			"id": "462",
 			"label": "Locate Creature",
 			"levels3d": {
 				"enable": true,
@@ -99367,7 +102186,7 @@
 			}
 		},
 		{
-			"id": "450",
+			"id": "463",
 			"label": "Longstrider",
 			"levels3d": {
 				"enable": true,
@@ -99620,7 +102439,7 @@
 			}
 		},
 		{
-			"id": "451",
+			"id": "464",
 			"label": "Maelstrom",
 			"levels3d": {
 				"type": "explosion",
@@ -99832,7 +102651,7 @@
 			}
 		},
 		{
-			"id": "452",
+			"id": "465",
 			"label": "Mage Hand",
 			"levels3d": {
 				"type": "explosion",
@@ -100044,7 +102863,7 @@
 			}
 		},
 		{
-			"id": "453",
+			"id": "466",
 			"label": "Magic Aura",
 			"levels3d": {
 				"enable": true,
@@ -100266,7 +103085,7 @@
 			}
 		},
 		{
-			"id": "454",
+			"id": "467",
 			"label": "Magic Jar",
 			"levels3d": {
 				"type": "explosion",
@@ -100479,7 +103298,7 @@
 			}
 		},
 		{
-			"id": "455",
+			"id": "468",
 			"label": "Magic Mouth",
 			"levels3d": {
 				"enable": true,
@@ -100701,7 +103520,7 @@
 			}
 		},
 		{
-			"id": "456",
+			"id": "469",
 			"label": "Magic Weapon",
 			"levels3d": {
 				"enable": true,
@@ -100920,7 +103739,7 @@
 			}
 		},
 		{
-			"id": "457",
+			"id": "470",
 			"label": "Magical Cunning",
 			"levels3d": {
 				"type": "explosion",
@@ -101132,7 +103951,7 @@
 			}
 		},
 		{
-			"id": "458",
+			"id": "471",
 			"label": "Magical Tinkering",
 			"levels3d": {
 				"type": "explosion",
@@ -101344,7 +104163,7 @@
 			}
 		},
 		{
-			"id": "459",
+			"id": "472",
 			"label": "Magnificent Mansion",
 			"levels3d": {
 				"type": "explosion",
@@ -101556,7 +104375,7 @@
 			}
 		},
 		{
-			"id": "460",
+			"id": "473",
 			"label": "Mantle of Inspiration",
 			"levels3d": {
 				"type": "explosion",
@@ -101768,7 +104587,7 @@
 			}
 		},
 		{
-			"id": "461",
+			"id": "474",
 			"label": "Mass Heal",
 			"levels3d": {
 				"enable": true,
@@ -102003,7 +104822,224 @@
 			}
 		},
 		{
-			"id": "462",
+			"id": "475",
+			"label": "Mass Polymorph",
+			"levels3d": {
+				"type": "castingsign",
+				"data": {
+					"color01": "#b2ff24",
+					"color02": "#f94b01",
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_06.webp",
+					"autoSize": true,
+					"alpha": 1,
+					"onCenter": true
+				},
+				"sound": {
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-growl-1.mp3"
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"color01": "#d4ff00",
+						"color02": "#2570e9",
+						"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_06.webp",
+						"autoSize": true,
+						"type": "explosion",
+						"alpha": 1,
+						"onCenter": true,
+						"rate": 25,
+						"duration": 1000
+					}
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				},
+				"enable": true
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "standard",
+					"variant": "02",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-growl-1.mp3",
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 7,
+					"repeatDelay": 1400,
+					"size": 1.25,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "darkyellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-long-2.mp3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 2,
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Mass Polymorph",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "476",
 			"label": "Meld into Stone",
 			"levels3d": {
 				"enable": true,
@@ -102229,7 +105265,7 @@
 			}
 		},
 		{
-			"id": "463",
+			"id": "477",
 			"label": "Melf's Minute Meteors",
 			"levels3d": {
 				"type": "explosion",
@@ -102441,7 +105477,7 @@
 			}
 		},
 		{
-			"id": "464",
+			"id": "478",
 			"label": "Mending",
 			"levels3d": {
 				"type": "explosion",
@@ -102653,7 +105689,228 @@
 			}
 		},
 		{
-			"id": "465",
+			"id": "479",
+			"label": "Mental Prison",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "illusion",
+					"variant": "runecomplete",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-7.mp3"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "default",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "chains",
+					"animation": "diamond",
+					"variant": "complete",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 500,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Mental Prison",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "480",
 			"label": "Metamagic",
 			"levels3d": {
 				"enable": true,
@@ -102874,7 +106131,7 @@
 			}
 		},
 		{
-			"id": "466",
+			"id": "481",
 			"label": "Meteor Swarm",
 			"levels3d": {
 				"type": "explosion",
@@ -103087,7 +106344,7 @@
 			}
 		},
 		{
-			"id": "467",
+			"id": "482",
 			"label": "Midnight Tears",
 			"levels3d": {
 				"type": "explosion",
@@ -103299,7 +106556,7 @@
 			}
 		},
 		{
-			"id": "468",
+			"id": "483",
 			"label": "Mighty Fortress",
 			"levels3d": {
 				"type": "explosion",
@@ -103512,7 +106769,7 @@
 			}
 		},
 		{
-			"id": "469",
+			"id": "484",
 			"label": "Mind Blank",
 			"levels3d": {
 				"type": "castingsign",
@@ -103729,7 +106986,7 @@
 			}
 		},
 		{
-			"id": "470",
+			"id": "485",
 			"label": "Mirror Image",
 			"levels3d": {
 				"enable": true,
@@ -103947,7 +107204,7 @@
 			}
 		},
 		{
-			"id": "471",
+			"id": "486",
 			"label": "Mislead",
 			"levels3d": {
 				"type": "castingsign",
@@ -104161,7 +107418,7 @@
 			}
 		},
 		{
-			"id": "472",
+			"id": "487",
 			"label": "Mold Earth",
 			"levels3d": {
 				"enable": true,
@@ -104386,7 +107643,7 @@
 			}
 		},
 		{
-			"id": "473",
+			"id": "488",
 			"label": "Mordenkainen's Sword",
 			"levels3d": {
 				"type": "explosion",
@@ -104598,7 +107855,220 @@
 			}
 		},
 		{
-			"id": "474",
+			"id": "489",
+			"label": "Motivational Speech",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "bardicinspiration",
+					"variant": "inspire",
+					"color": "purplepink",
+					"enableCustom": true,
+					"customPath": "jb2a.music_notations.treble_clef.purple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": -1000,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "target",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "bardicinspiration",
+					"variant": "inspire",
+					"color": "purplepink",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hellish-Rebuke.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Motivational Speech",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "490",
 			"label": "Move Earth",
 			"levels3d": {
 				"type": "explosion",
@@ -104813,7 +108283,7 @@
 			}
 		},
 		{
-			"id": "475",
+			"id": "491",
 			"label": "Natural Recovery",
 			"levels3d": {
 				"type": "explosion",
@@ -105025,7 +108495,7 @@
 			}
 		},
 		{
-			"id": "476",
+			"id": "492",
 			"label": "Net",
 			"levels3d": {
 				"enable": true,
@@ -105250,7 +108720,7 @@
 			}
 		},
 		{
-			"id": "477",
+			"id": "493",
 			"label": "Nondetection",
 			"levels3d": {
 				"enable": true,
@@ -105471,7 +108941,7 @@
 			}
 		},
 		{
-			"id": "478",
+			"id": "494",
 			"label": "Oil of Taggit",
 			"levels3d": {
 				"type": "explosion",
@@ -105683,7 +109153,7 @@
 			}
 		},
 		{
-			"id": "479",
+			"id": "495",
 			"label": "Overchannel",
 			"levels3d": {
 				"type": "explosion",
@@ -105896,7 +109366,7 @@
 			}
 		},
 		{
-			"id": "480",
+			"id": "496",
 			"label": "Pale Tincture",
 			"levels3d": {
 				"type": "explosion",
@@ -106108,7 +109578,7 @@
 			}
 		},
 		{
-			"id": "481",
+			"id": "497",
 			"label": "Passwall",
 			"levels3d": {
 				"enable": true,
@@ -106326,7 +109796,7 @@
 			}
 		},
 		{
-			"id": "482",
+			"id": "498",
 			"label": "Patient Defense",
 			"levels3d": {
 				"type": "explosion",
@@ -106538,7 +110008,7 @@
 			}
 		},
 		{
-			"id": "483",
+			"id": "499",
 			"label": "Perfect Self",
 			"levels3d": {
 				"type": "explosion",
@@ -106750,7 +110220,7 @@
 			}
 		},
 		{
-			"id": "484",
+			"id": "500",
 			"label": "Phantasmal Killer",
 			"levels3d": {
 				"type": "castingsign",
@@ -106964,7 +110434,7 @@
 			}
 		},
 		{
-			"id": "485",
+			"id": "501",
 			"label": "Phantom Steed",
 			"levels3d": {
 				"enable": true,
@@ -107184,7 +110654,7 @@
 			}
 		},
 		{
-			"id": "486",
+			"id": "502",
 			"label": "Planar Ally",
 			"levels3d": {
 				"type": "castingsign",
@@ -107399,7 +110869,7 @@
 			}
 		},
 		{
-			"id": "487",
+			"id": "503",
 			"label": "Plane Shift",
 			"levels3d": {
 				"type": "castingsign",
@@ -107615,7 +111085,7 @@
 			}
 		},
 		{
-			"id": "488",
+			"id": "504",
 			"label": "Plant Growth",
 			"levels3d": {
 				"enable": true,
@@ -107834,7 +111304,7 @@
 			}
 		},
 		{
-			"id": "489",
+			"id": "505",
 			"label": "Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -108046,7 +111516,7 @@
 			}
 		},
 		{
-			"id": "490",
+			"id": "506",
 			"label": "Polymorph",
 			"levels3d": {
 				"type": "castingsign",
@@ -108263,7 +111733,7 @@
 			}
 		},
 		{
-			"id": "491",
+			"id": "507",
 			"label": "Potion of",
 			"levels3d": {
 				"type": "vortex",
@@ -108477,7 +111947,7 @@
 			}
 		},
 		{
-			"id": "492",
+			"id": "508",
 			"label": "Potion of Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -108689,7 +112159,7 @@
 			}
 		},
 		{
-			"id": "493",
+			"id": "509",
 			"label": "Power Word",
 			"levels3d": {
 				"enable": true,
@@ -108907,7 +112377,7 @@
 			}
 		},
 		{
-			"id": "494",
+			"id": "510",
 			"label": "Power Word Fortify",
 			"levels3d": {
 				"enable": true,
@@ -109125,7 +112595,7 @@
 			}
 		},
 		{
-			"id": "495",
+			"id": "511",
 			"label": "Power Word Heal",
 			"levels3d": {
 				"enable": true,
@@ -109346,7 +112816,7 @@
 			}
 		},
 		{
-			"id": "496",
+			"id": "512",
 			"label": "Power Word Kill",
 			"levels3d": {
 				"enable": true,
@@ -109564,7 +113034,7 @@
 			}
 		},
 		{
-			"id": "497",
+			"id": "513",
 			"label": "Power Word Pain",
 			"levels3d": {
 				"enable": true,
@@ -109782,7 +113252,7 @@
 			}
 		},
 		{
-			"id": "498",
+			"id": "514",
 			"label": "Power Word Stun",
 			"levels3d": {
 				"enable": true,
@@ -110000,7 +113470,7 @@
 			}
 		},
 		{
-			"id": "499",
+			"id": "515",
 			"label": "Prayer of Healing",
 			"levels3d": {
 				"enable": true,
@@ -110221,7 +113691,7 @@
 			}
 		},
 		{
-			"id": "500",
+			"id": "516",
 			"label": "Preserve Life",
 			"levels3d": {
 				"type": "explosion",
@@ -110434,7 +113904,7 @@
 			}
 		},
 		{
-			"id": "501",
+			"id": "517",
 			"label": "Prestidigitation",
 			"levels3d": {
 				"type": "explosion",
@@ -110646,7 +114116,7 @@
 			}
 		},
 		{
-			"id": "502",
+			"id": "518",
 			"label": "Primal Companion",
 			"levels3d": {
 				"type": "explosion",
@@ -110858,7 +114328,7 @@
 			}
 		},
 		{
-			"id": "503",
+			"id": "519",
 			"label": "Primeval Awareness",
 			"levels3d": {
 				"type": "explosion",
@@ -111070,7 +114540,7 @@
 			}
 		},
 		{
-			"id": "504",
+			"id": "520",
 			"levels3d": {
 				"type": "explosion",
 				"data": {
@@ -111283,7 +114753,7 @@
 			}
 		},
 		{
-			"id": "505",
+			"id": "521",
 			"label": "Project Image",
 			"levels3d": {
 				"type": "castingsign",
@@ -111498,7 +114968,7 @@
 			}
 		},
 		{
-			"id": "506",
+			"id": "522",
 			"label": "Projected Ward",
 			"levels3d": {
 				"type": "explosion",
@@ -111710,7 +115180,7 @@
 			}
 		},
 		{
-			"id": "507",
+			"id": "523",
 			"label": "Protection from Evil and Good",
 			"levels3d": {
 				"enable": true,
@@ -111927,7 +115397,7 @@
 			}
 		},
 		{
-			"id": "508",
+			"id": "524",
 			"label": "Protection from Poison",
 			"levels3d": {
 				"enable": true,
@@ -112148,7 +115618,7 @@
 			}
 		},
 		{
-			"id": "509",
+			"id": "525",
 			"label": "Purple Worm Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -112360,7 +115830,7 @@
 			}
 		},
 		{
-			"id": "510",
+			"id": "526",
 			"label": "Quickened Healing",
 			"levels3d": {
 				"enable": true,
@@ -112581,7 +116051,7 @@
 			}
 		},
 		{
-			"id": "511",
+			"id": "527",
 			"label": "Radiant Soul",
 			"levels3d": {
 				"type": "explosion",
@@ -112793,7 +116263,7 @@
 			}
 		},
 		{
-			"id": "512",
+			"id": "528",
 			"label": "Rage",
 			"levels3d": {
 				"enable": true,
@@ -113017,7 +116487,7 @@
 			}
 		},
 		{
-			"id": "513",
+			"id": "529",
 			"label": "Raise Dead",
 			"levels3d": {
 				"enable": true,
@@ -113239,7 +116709,7 @@
 			}
 		},
 		{
-			"id": "514",
+			"id": "530",
 			"label": "Raulothim's Psychic Lance",
 			"levels3d": {
 				"type": "explosion",
@@ -113452,7 +116922,7 @@
 			}
 		},
 		{
-			"id": "515",
+			"id": "531",
 			"label": "Regenerate",
 			"levels3d": {
 				"enable": true,
@@ -113672,7 +117142,7 @@
 			}
 		},
 		{
-			"id": "516",
+			"id": "532",
 			"label": "Reincarnate",
 			"levels3d": {
 				"enable": true,
@@ -113894,7 +117364,7 @@
 			}
 		},
 		{
-			"id": "517",
+			"id": "533",
 			"label": "Relentless Endurance",
 			"levels3d": {
 				"type": "explosion",
@@ -114106,7 +117576,7 @@
 			}
 		},
 		{
-			"id": "518",
+			"id": "534",
 			"label": "Remove Curse",
 			"levels3d": {
 				"enable": true,
@@ -114328,7 +117798,219 @@
 			}
 		},
 		{
-			"id": "519",
+			"id": "535",
+			"label": "Repair",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.hammer.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 600,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Repair",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "536",
 			"label": "Resilient Sphere",
 			"levels3d": {
 				"type": "castingsign",
@@ -114543,7 +118225,7 @@
 			}
 		},
 		{
-			"id": "520",
+			"id": "537",
 			"label": "Restoration",
 			"levels3d": {
 				"enable": true,
@@ -114766,7 +118448,7 @@
 			}
 		},
 		{
-			"id": "521",
+			"id": "538",
 			"label": "Resurrection",
 			"levels3d": {
 				"enable": true,
@@ -114990,7 +118672,7 @@
 			}
 		},
 		{
-			"id": "522",
+			"id": "539",
 			"label": "Revelation in Flesh",
 			"levels3d": {
 				"type": "explosion",
@@ -115202,7 +118884,7 @@
 			}
 		},
 		{
-			"id": "523",
+			"id": "540",
 			"label": "Revivify",
 			"levels3d": {
 				"enable": true,
@@ -115424,7 +119106,7 @@
 			}
 		},
 		{
-			"id": "524",
+			"id": "541",
 			"label": "Rope Trick",
 			"levels3d": {
 				"enable": true,
@@ -115646,7 +119328,7 @@
 			}
 		},
 		{
-			"id": "525",
+			"id": "542",
 			"label": "Sacred Flame",
 			"levels3d": {
 				"type": "explosion",
@@ -115859,7 +119541,7 @@
 			}
 		},
 		{
-			"id": "526",
+			"id": "543",
 			"label": "Sacred Weapon",
 			"levels3d": {
 				"type": "explosion",
@@ -116071,7 +119753,7 @@
 			}
 		},
 		{
-			"id": "527",
+			"id": "544",
 			"label": "Sanctuary",
 			"levels3d": {
 				"enable": true,
@@ -116291,7 +119973,7 @@
 			}
 		},
 		{
-			"id": "528",
+			"id": "545",
 			"label": "Sapping Sting",
 			"levels3d": {
 				"enable": true,
@@ -116513,7 +120195,7 @@
 			}
 		},
 		{
-			"id": "529",
+			"id": "546",
 			"label": "Scatter",
 			"levels3d": {
 				"enable": true,
@@ -116735,7 +120417,7 @@
 			}
 		},
 		{
-			"id": "530",
+			"id": "547",
 			"label": "Scrying",
 			"levels3d": {
 				"type": "castingsign",
@@ -116953,7 +120635,7 @@
 			}
 		},
 		{
-			"id": "531",
+			"id": "548",
 			"label": "Sear Undead",
 			"levels3d": {
 				"type": "explosion",
@@ -117165,7 +120847,7 @@
 			}
 		},
 		{
-			"id": "532",
+			"id": "549",
 			"label": "Searing Vengeance",
 			"levels3d": {
 				"type": "explosion",
@@ -117378,7 +121060,7 @@
 			}
 		},
 		{
-			"id": "533",
+			"id": "550",
 			"label": "Second Wind",
 			"levels3d": {
 				"enable": true,
@@ -117601,7 +121283,7 @@
 			}
 		},
 		{
-			"id": "534",
+			"id": "551",
 			"label": "Secret Chest",
 			"levels3d": {
 				"enable": true,
@@ -117824,7 +121506,7 @@
 			}
 		},
 		{
-			"id": "535",
+			"id": "552",
 			"label": "See Invisibility",
 			"levels3d": {
 				"enable": true,
@@ -118048,7 +121730,7 @@
 			}
 		},
 		{
-			"id": "536",
+			"id": "553",
 			"label": "Seeming",
 			"levels3d": {
 				"type": "castingsign",
@@ -118265,7 +121947,7 @@
 			}
 		},
 		{
-			"id": "537",
+			"id": "554",
 			"label": "Sending",
 			"levels3d": {
 				"enable": true,
@@ -118484,7 +122166,7 @@
 			}
 		},
 		{
-			"id": "538",
+			"id": "555",
 			"label": "Sequester",
 			"levels3d": {
 				"type": "explosion",
@@ -118697,7 +122379,7 @@
 			}
 		},
 		{
-			"id": "539",
+			"id": "556",
 			"label": "Serpent Venom",
 			"levels3d": {
 				"type": "explosion",
@@ -118909,7 +122591,7 @@
 			}
 		},
 		{
-			"id": "540",
+			"id": "557",
 			"label": "Shadow Blade",
 			"levels3d": {
 				"type": "castingsign",
@@ -119149,7 +122831,7 @@
 			}
 		},
 		{
-			"id": "541",
+			"id": "558",
 			"label": "Shadow of Moil",
 			"levels3d": {
 				"enable": true,
@@ -119371,7 +123053,7 @@
 			}
 		},
 		{
-			"id": "542",
+			"id": "559",
 			"label": "Shape Water",
 			"levels3d": {
 				"enable": true,
@@ -119593,7 +123275,7 @@
 			}
 		},
 		{
-			"id": "543",
+			"id": "560",
 			"label": "Shapechange",
 			"levels3d": {
 				"type": "castingsign",
@@ -119810,7 +123492,7 @@
 			}
 		},
 		{
-			"id": "544",
+			"id": "561",
 			"label": "Shillelagh",
 			"levels3d": {
 				"type": "explosion",
@@ -120022,7 +123704,7 @@
 			}
 		},
 		{
-			"id": "545",
+			"id": "562",
 			"label": "Silvery Barbs",
 			"levels3d": {
 				"type": "explosion",
@@ -120234,7 +123916,7 @@
 			}
 		},
 		{
-			"id": "546",
+			"id": "563",
 			"label": "Simulacrum",
 			"levels3d": {
 				"type": "explosion",
@@ -120446,7 +124128,7 @@
 			}
 		},
 		{
-			"id": "547",
+			"id": "564",
 			"label": "Skill Empowerment",
 			"levels3d": {
 				"enable": true,
@@ -120692,7 +124374,7 @@
 			}
 		},
 		{
-			"id": "548",
+			"id": "565",
 			"label": "Skywrite",
 			"levels3d": {
 				"type": "explosion",
@@ -120904,7 +124586,7 @@
 			}
 		},
 		{
-			"id": "549",
+			"id": "566",
 			"label": "Slow Fall",
 			"levels3d": {
 				"type": "explosion",
@@ -121116,7 +124798,7 @@
 			}
 		},
 		{
-			"id": "550",
+			"id": "567",
 			"label": "Smite",
 			"levels3d": {
 				"enable": true,
@@ -121341,7 +125023,7 @@
 			}
 		},
 		{
-			"id": "551",
+			"id": "568",
 			"label": "Snare",
 			"levels3d": {
 				"enable": true,
@@ -121561,7 +125243,7 @@
 			}
 		},
 		{
-			"id": "552",
+			"id": "569",
 			"label": "Sneak Attack",
 			"levels3d": {
 				"type": "slash",
@@ -121776,7 +125458,7 @@
 			}
 		},
 		{
-			"id": "553",
+			"id": "570",
 			"label": "Song of Rest",
 			"levels3d": {
 				"type": "explosion",
@@ -122011,7 +125693,7 @@
 			}
 		},
 		{
-			"id": "554",
+			"id": "571",
 			"label": "Sorcerous Restoration",
 			"levels3d": {
 				"type": "explosion",
@@ -122223,7 +125905,7 @@
 			}
 		},
 		{
-			"id": "555",
+			"id": "572",
 			"label": "Sorcery Incarnate",
 			"levels3d": {
 				"type": "explosion",
@@ -122435,7 +126117,7 @@
 			}
 		},
 		{
-			"id": "556",
+			"id": "573",
 			"label": "Sorcery Points",
 			"levels3d": {
 				"type": "explosion",
@@ -122647,7 +126329,7 @@
 			}
 		},
 		{
-			"id": "557",
+			"id": "574",
 			"label": "Soul of Artifice",
 			"levels3d": {
 				"type": "explosion",
@@ -122859,7 +126541,7 @@
 			}
 		},
 		{
-			"id": "558",
+			"id": "575",
 			"label": "Spare the Dying",
 			"levels3d": {
 				"type": "explosion",
@@ -123071,7 +126753,7 @@
 			}
 		},
 		{
-			"id": "559",
+			"id": "576",
 			"label": "Speak with Animals",
 			"levels3d": {
 				"enable": true,
@@ -123291,7 +126973,7 @@
 			}
 		},
 		{
-			"id": "560",
+			"id": "577",
 			"label": "Speak with Dead",
 			"levels3d": {
 				"enable": true,
@@ -123508,7 +127190,7 @@
 			}
 		},
 		{
-			"id": "561",
+			"id": "578",
 			"label": "Speak with Plants",
 			"levels3d": {
 				"enable": true,
@@ -123727,7 +127409,7 @@
 			}
 		},
 		{
-			"id": "562",
+			"id": "579",
 			"label": "Spectral Fangs",
 			"levels3d": {
 				"type": "slash",
@@ -123942,7 +127624,7 @@
 			}
 		},
 		{
-			"id": "563",
+			"id": "580",
 			"label": "Spell Thief",
 			"levels3d": {
 				"type": "slash",
@@ -124157,7 +127839,7 @@
 			}
 		},
 		{
-			"id": "564",
+			"id": "581",
 			"label": "Spider Climb",
 			"levels3d": {
 				"enable": true,
@@ -124391,7 +128073,230 @@
 			}
 		},
 		{
-			"id": "565",
+			"id": "582",
+			"label": "Spirit of Death",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
+					"color01": "#ff00a2",
+					"color02": "#2bff00",
+					"alpha": 1,
+					"onCenter": true
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
+						"type": "holy",
+						"color01": "#6c15ef",
+						"color02": "#60745d",
+						"alpha": 1,
+						"onCenter": false,
+						"speed": 15,
+						"rate": 26
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-short-5.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-2.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "necromancy",
+					"variant": "complete",
+					"color": "green",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Spirit of Death",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "583",
 			"label": "Spiritual Weapon",
 			"levels3d": {
 				"enable": true,
@@ -124612,7 +128517,7 @@
 			}
 		},
 		{
-			"id": "566",
+			"id": "584",
 			"label": "Spore",
 			"levels3d": {
 				"type": "fairy",
@@ -124828,7 +128733,7 @@
 			}
 		},
 		{
-			"id": "567",
+			"id": "585",
 			"label": "Stalker's Flurry",
 			"levels3d": {
 				"type": "explosion",
@@ -125040,7 +128945,219 @@
 			}
 		},
 		{
-			"id": "568",
+			"id": "586",
+			"label": "Steel Defender",
+			"levels3d": {
+				"type": "explosion",
+				"data": {
+					"color01": "#FFFFFF",
+					"color02": "#FFFFFF",
+					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+				},
+				"sound": {
+					"enable": false
+				},
+				"secondary": {
+					"enable": false,
+					"data": {
+						"color01": "#FFFFFF",
+						"color02": "#FFFFFF",
+						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
+					}
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.melee_attack.02.hammer.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 600,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 3,
+					"repeatDelay": 1000,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Steel Defender",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "587",
 			"label": "Step of the Wind",
 			"levels3d": {
 				"type": "explosion",
@@ -125252,7 +129369,7 @@
 			}
 		},
 		{
-			"id": "569",
+			"id": "588",
 			"label": "Stillness of Mind",
 			"levels3d": {
 				"enable": true,
@@ -125500,7 +129617,7 @@
 			}
 		},
 		{
-			"id": "570",
+			"id": "589",
 			"label": "Stone Shape",
 			"levels3d": {
 				"type": "castingsign",
@@ -125715,7 +129832,7 @@
 			}
 		},
 		{
-			"id": "571",
+			"id": "590",
 			"label": "Storm of Vengeance",
 			"levels3d": {
 				"type": "explosion",
@@ -125928,7 +130045,7 @@
 			}
 		},
 		{
-			"id": "572",
+			"id": "591",
 			"label": "Stroke of Luck",
 			"levels3d": {
 				"type": "explosion",
@@ -126140,7 +130257,7 @@
 			}
 		},
 		{
-			"id": "573",
+			"id": "592",
 			"label": "Suggestion",
 			"levels3d": {
 				"enable": true,
@@ -126367,7 +130484,7 @@
 			}
 		},
 		{
-			"id": "574",
+			"id": "593",
 			"label": "Summon Aberration",
 			"levels3d": {
 				"enable": true,
@@ -126590,7 +130707,7 @@
 			}
 		},
 		{
-			"id": "575",
+			"id": "594",
 			"label": "Summon Beast",
 			"levels3d": {
 				"enable": true,
@@ -126813,7 +130930,7 @@
 			}
 		},
 		{
-			"id": "576",
+			"id": "595",
 			"label": "Summon Celestial",
 			"levels3d": {
 				"enable": true,
@@ -127036,7 +131153,7 @@
 			}
 		},
 		{
-			"id": "577",
+			"id": "596",
 			"label": "Summon Construct",
 			"levels3d": {
 				"enable": true,
@@ -127259,7 +131376,7 @@
 			}
 		},
 		{
-			"id": "578",
+			"id": "597",
 			"label": "Summon Draconic Spirit",
 			"levels3d": {
 				"enable": true,
@@ -127482,7 +131599,7 @@
 			}
 		},
 		{
-			"id": "579",
+			"id": "598",
 			"label": "Summon Dragon",
 			"levels3d": {
 				"enable": true,
@@ -127705,7 +131822,7 @@
 			}
 		},
 		{
-			"id": "580",
+			"id": "599",
 			"label": "Summon Elemental",
 			"levels3d": {
 				"enable": true,
@@ -127928,7 +132045,7 @@
 			}
 		},
 		{
-			"id": "581",
+			"id": "600",
 			"label": "Summon Fey",
 			"levels3d": {
 				"enable": true,
@@ -128151,7 +132268,7 @@
 			}
 		},
 		{
-			"id": "582",
+			"id": "601",
 			"label": "Summon Fiend",
 			"levels3d": {
 				"enable": true,
@@ -128374,7 +132491,7 @@
 			}
 		},
 		{
-			"id": "583",
+			"id": "602",
 			"label": "Summon Greater Demon",
 			"levels3d": {
 				"enable": true,
@@ -128597,7 +132714,7 @@
 			}
 		},
 		{
-			"id": "584",
+			"id": "603",
 			"label": "Summon Lesser Demon",
 			"levels3d": {
 				"enable": true,
@@ -128820,7 +132937,7 @@
 			}
 		},
 		{
-			"id": "585",
+			"id": "604",
 			"label": "Summon Shadowspawn",
 			"levels3d": {
 				"enable": true,
@@ -129043,7 +133160,7 @@
 			}
 		},
 		{
-			"id": "586",
+			"id": "605",
 			"label": "Summon Undead",
 			"levels3d": {
 				"enable": true,
@@ -129266,7 +133383,7 @@
 			}
 		},
 		{
-			"id": "587",
+			"id": "606",
 			"label": "Supreme Sneak",
 			"levels3d": {
 				"type": "explosion",
@@ -129480,7 +133597,7 @@
 			}
 		},
 		{
-			"id": "588",
+			"id": "607",
 			"label": "Swallow",
 			"levels3d": {
 				"type": "jb2aexplosionnolight",
@@ -129694,7 +133811,7 @@
 			}
 		},
 		{
-			"id": "589",
+			"id": "608",
 			"label": "Swift Quiver",
 			"levels3d": {
 				"type": "castingsign",
@@ -129908,7 +134025,7 @@
 			}
 		},
 		{
-			"id": "590",
+			"id": "609",
 			"label": "Sword Burst",
 			"levels3d": {
 				"type": "explosion",
@@ -130120,7 +134237,7 @@
 			}
 		},
 		{
-			"id": "591",
+			"id": "610",
 			"label": "Symbol",
 			"levels3d": {
 				"type": "castingsign",
@@ -130335,7 +134452,7 @@
 			}
 		},
 		{
-			"id": "592",
+			"id": "611",
 			"label": "Tactical Mind",
 			"levels3d": {
 				"type": "explosion",
@@ -130547,7 +134664,7 @@
 			}
 		},
 		{
-			"id": "593",
+			"id": "612",
 			"label": "Tactical Shift",
 			"levels3d": {
 				"type": "explosion",
@@ -130759,7 +134876,7 @@
 			}
 		},
 		{
-			"id": "594",
+			"id": "613",
 			"label": "Talon",
 			"levels3d": {
 				"enable": true,
@@ -130977,7 +135094,7 @@
 			}
 		},
 		{
-			"id": "595",
+			"id": "614",
 			"label": "Tamed Surge",
 			"levels3d": {
 				"type": "explosion",
@@ -131189,7 +135306,7 @@
 			}
 		},
 		{
-			"id": "596",
+			"id": "615",
 			"label": "Tasha's Otherworldly Guise",
 			"levels3d": {
 				"enable": true,
@@ -131412,7 +135529,7 @@
 			}
 		},
 		{
-			"id": "597",
+			"id": "616",
 			"label": "Telekinesis",
 			"levels3d": {
 				"type": "castingsign",
@@ -131627,7 +135744,7 @@
 			}
 		},
 		{
-			"id": "598",
+			"id": "617",
 			"label": "Telekinetic",
 			"levels3d": {
 				"type": "explosion",
@@ -131839,7 +135956,7 @@
 			}
 		},
 		{
-			"id": "599",
+			"id": "618",
 			"label": "Telepathy",
 			"levels3d": {
 				"type": "explosion",
@@ -132054,7 +136171,7 @@
 			}
 		},
 		{
-			"id": "600",
+			"id": "619",
 			"label": "Teleportation Circle",
 			"levels3d": {
 				"type": "explosion",
@@ -132267,7 +136384,7 @@
 			}
 		},
 		{
-			"id": "601",
+			"id": "620",
 			"label": "Temple of the Gods",
 			"levels3d": {
 				"type": "explosion",
@@ -132479,7 +136596,7 @@
 			}
 		},
 		{
-			"id": "602",
+			"id": "621",
 			"label": "Tenser's Transformation",
 			"levels3d": {
 				"type": "explosion",
@@ -132691,7 +136808,7 @@
 			}
 		},
 		{
-			"id": "603",
+			"id": "622",
 			"label": "Tentacle",
 			"levels3d": {
 				"enable": true,
@@ -132913,7 +137030,7 @@
 			}
 		},
 		{
-			"id": "604",
+			"id": "623",
 			"label": "Thaumaturgy",
 			"levels3d": {
 				"type": "explosion",
@@ -133126,7 +137243,7 @@
 			}
 		},
 		{
-			"id": "605",
+			"id": "624",
 			"label": "Thorn Whip",
 			"levels3d": {
 				"type": "explosion",
@@ -133341,7 +137458,7 @@
 			}
 		},
 		{
-			"id": "606",
+			"id": "625",
 			"label": "Tidal Wave",
 			"levels3d": {
 				"type": "explosion",
@@ -133553,7 +137670,7 @@
 			}
 		},
 		{
-			"id": "607",
+			"id": "626",
 			"label": "Tides of Chaos",
 			"levels3d": {
 				"type": "explosion",
@@ -133765,7 +137882,7 @@
 			}
 		},
 		{
-			"id": "608",
+			"id": "627",
 			"label": "Time Stop",
 			"levels3d": {
 				"enable": true,
@@ -133984,7 +138101,7 @@
 			}
 		},
 		{
-			"id": "609",
+			"id": "628",
 			"label": "Tiny Servant",
 			"levels3d": {
 				"enable": true,
@@ -134201,7 +138318,7 @@
 			}
 		},
 		{
-			"id": "610",
+			"id": "629",
 			"label": "Tireless",
 			"levels3d": {
 				"type": "explosion",
@@ -134413,7 +138530,7 @@
 			}
 		},
 		{
-			"id": "611",
+			"id": "630",
 			"label": "Toll the Dead",
 			"levels3d": {
 				"type": "explosion",
@@ -134625,7 +138742,7 @@
 			}
 		},
 		{
-			"id": "612",
+			"id": "631",
 			"label": "Tongue",
 			"levels3d": {
 				"type": "slash",
@@ -134841,7 +138958,7 @@
 			}
 		},
 		{
-			"id": "613",
+			"id": "632",
 			"label": "Tongues",
 			"levels3d": {
 				"enable": true,
@@ -135062,7 +139179,7 @@
 			}
 		},
 		{
-			"id": "614",
+			"id": "633",
 			"label": "Torpor",
 			"levels3d": {
 				"type": "explosion",
@@ -135274,7 +139391,7 @@
 			}
 		},
 		{
-			"id": "615",
+			"id": "634",
 			"label": "Touch",
 			"levels3d": {
 				"type": "slash",
@@ -135489,7 +139606,7 @@
 			}
 		},
 		{
-			"id": "616",
+			"id": "635",
 			"label": "Transport via Plants",
 			"levels3d": {
 				"type": "explosion",
@@ -135701,7 +139818,7 @@
 			}
 		},
 		{
-			"id": "617",
+			"id": "636",
 			"label": "Tree Stride",
 			"levels3d": {
 				"type": "castingsign",
@@ -135916,7 +140033,7 @@
 			}
 		},
 		{
-			"id": "618",
+			"id": "637",
 			"label": "True Seeing",
 			"levels3d": {
 				"enable": true,
@@ -136140,7 +140257,7 @@
 			}
 		},
 		{
-			"id": "619",
+			"id": "638",
 			"label": "True Strike",
 			"levels3d": {
 				"type": "explosion",
@@ -136352,7 +140469,7 @@
 			}
 		},
 		{
-			"id": "620",
+			"id": "639",
 			"label": "Truth Serum",
 			"levels3d": {
 				"type": "explosion",
@@ -136564,7 +140681,7 @@
 			}
 		},
 		{
-			"id": "621",
+			"id": "640",
 			"label": "Tsunami",
 			"levels3d": {
 				"type": "explosion",
@@ -136777,7 +140894,7 @@
 			}
 		},
 		{
-			"id": "622",
+			"id": "641",
 			"label": "Uncanny Dodge",
 			"levels3d": {
 				"type": "explosion",
@@ -136989,7 +141106,7 @@
 			}
 		},
 		{
-			"id": "623",
+			"id": "642",
 			"label": "Uncanny Metabolism",
 			"levels3d": {
 				"type": "explosion",
@@ -137201,7 +141318,7 @@
 			}
 		},
 		{
-			"id": "624",
+			"id": "643",
 			"label": "Undying Sentinel",
 			"levels3d": {
 				"type": "explosion",
@@ -137413,7 +141530,7 @@
 			}
 		},
 		{
-			"id": "625",
+			"id": "644",
 			"label": "Unseen Servant",
 			"levels3d": {
 				"enable": true,
@@ -137630,7 +141747,7 @@
 			}
 		},
 		{
-			"id": "626",
+			"id": "645",
 			"label": "Unsettling Words",
 			"levels3d": {
 				"type": "castingsign",
@@ -137862,7 +141979,7 @@
 			}
 		},
 		{
-			"id": "627",
+			"id": "646",
 			"label": "Vanish",
 			"levels3d": {
 				"type": "explosion",
@@ -138074,7 +142191,7 @@
 			}
 		},
 		{
-			"id": "628",
+			"id": "647",
 			"label": "Vicious Mockery",
 			"levels3d": {
 				"type": "explosion",
@@ -138286,7 +142403,7 @@
 			}
 		},
 		{
-			"id": "629",
+			"id": "648",
 			"label": "Vigilant Blessing",
 			"levels3d": {
 				"type": "mysteriouslights",
@@ -138495,7 +142612,7 @@
 			}
 		},
 		{
-			"id": "630",
+			"id": "649",
 			"label": "Vitality of the Tree",
 			"levels3d": {
 				"type": "explosion",
@@ -138707,7 +142824,7 @@
 			}
 		},
 		{
-			"id": "631",
+			"id": "650",
 			"label": "Vortex Warp",
 			"levels3d": {
 				"enable": true,
@@ -138929,7 +143046,7 @@
 			}
 		},
 		{
-			"id": "632",
+			"id": "651",
 			"label": "Vow of Enmity",
 			"levels3d": {
 				"type": "explosion",
@@ -139141,7 +143258,7 @@
 			}
 		},
 		{
-			"id": "633",
+			"id": "652",
 			"label": "War Bond",
 			"levels3d": {
 				"type": "explosion",
@@ -139353,7 +143470,7 @@
 			}
 		},
 		{
-			"id": "634",
+			"id": "653",
 			"label": "Warding Bond",
 			"levels3d": {
 				"enable": true,
@@ -139574,7 +143691,7 @@
 			}
 		},
 		{
-			"id": "635",
+			"id": "654",
 			"label": "Warding Flare",
 			"levels3d": {
 				"type": "explosion",
@@ -139786,7 +143903,228 @@
 			}
 		},
 		{
-			"id": "636",
+			"id": "655",
+			"label": "Warp Sense",
+			"levels3d": {
+				"enable": true,
+				"type": "castingsign",
+				"data": {
+					"autoSize": true,
+					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_04.webp",
+					"alpha": 1,
+					"color01": "#00aaff",
+					"color02": "#a8f5f0"
+				},
+				"secondary": {
+					"enable": true,
+					"data": {
+						"autoSize": true,
+						"spritePath": "jb2a.magic_signs.circle.01.divination",
+						"type": "jb2aexplosion",
+						"onCenter": true,
+						"rate": 5,
+						"life": 700,
+						"alpha": 1,
+						"scale": 1
+					}
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-5.mp3",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"tokens": {
+					"enable": true,
+					"source": true,
+					"target": false,
+					"sourceType": "twirl",
+					"sourcePlay": "start",
+					"targetType": "shake",
+					"targetPlay": "end"
+				}
+			},
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "ontoken",
+			"primary": {
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": false,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-5.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "divination",
+					"variant": "01",
+					"color": "lightblue",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Warp Sense",
+				"menu": "ontoken",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "656",
 			"label": "Warrior of the Gods",
 			"levels3d": {
 				"type": "explosion",
@@ -139999,7 +144337,7 @@
 			}
 		},
 		{
-			"id": "637",
+			"id": "657",
 			"label": "Water Breathing",
 			"levels3d": {
 				"enable": true,
@@ -140223,7 +144561,7 @@
 			}
 		},
 		{
-			"id": "638",
+			"id": "658",
 			"label": "Water Walk",
 			"levels3d": {
 				"enable": true,
@@ -140448,7 +144786,7 @@
 			}
 		},
 		{
-			"id": "639",
+			"id": "659",
 			"label": "Wholeness of Body",
 			"levels3d": {
 				"type": "explosion",
@@ -140660,7 +144998,7 @@
 			}
 		},
 		{
-			"id": "640",
+			"id": "660",
 			"label": "Wild Resurgence",
 			"levels3d": {
 				"enable": true,
@@ -140878,7 +145216,7 @@
 			}
 		},
 		{
-			"id": "641",
+			"id": "661",
 			"label": "Wild Shape",
 			"levels3d": {
 				"enable": true,
@@ -141095,7 +145433,7 @@
 			}
 		},
 		{
-			"id": "642",
+			"id": "662",
 			"label": "Wind Walk",
 			"levels3d": {
 				"type": "castingsign",
@@ -141311,7 +145649,7 @@
 			}
 		},
 		{
-			"id": "643",
+			"id": "663",
 			"label": "Wish",
 			"levels3d": {
 				"type": "castingsign",
@@ -141527,7 +145865,7 @@
 			}
 		},
 		{
-			"id": "644",
+			"id": "664",
 			"label": "Withering Touch",
 			"levels3d": {
 				"type": "castingsign",
@@ -141744,7 +146082,7 @@
 			}
 		},
 		{
-			"id": "645",
+			"id": "665",
 			"label": "Word of Radiance",
 			"levels3d": {
 				"enable": true,
@@ -141972,7 +146310,7 @@
 			}
 		},
 		{
-			"id": "646",
+			"id": "666",
 			"label": "Word of Recall",
 			"levels3d": {
 				"type": "explosion",
@@ -142184,7 +146522,7 @@
 			}
 		},
 		{
-			"id": "647",
+			"id": "667",
 			"label": "Wyvern Poison",
 			"levels3d": {
 				"type": "explosion",
@@ -142396,7 +146734,7 @@
 			}
 		},
 		{
-			"id": "648",
+			"id": "668",
 			"label": "Zealous Presence",
 			"levels3d": {
 				"type": "explosion",
@@ -142609,7 +146947,7 @@
 			}
 		},
 		{
-			"id": "649",
+			"id": "669",
 			"label": "Zephyr Strike",
 			"levels3d": {
 				"enable": true,
@@ -142829,4570 +147167,11 @@
 				"moduleVersion": "2.0.0",
 				"version": 1686753301417
 			}
-		},
-		{
-			"id": "650",
-			"label": "Absorb Elements",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.energy_attack.01.multicolored01"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.25,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Absorb Elements",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "651",
-			"label": "Arcane Armor",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "complete",
-					"variant": "03",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.magic_signs.rune.02.complete"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Arcane Armor",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "652",
-			"label": "Arcane Jolt",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "energystrand",
-					"variant": "01",
-					"color": "blueorange",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Arcane Jolt",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "653",
-			"label": "Armor Model",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "complete",
-					"variant": "03",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.magic_signs.rune.02.complete"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Armor Model",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "654",
-			"label": "Cause Fear",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_13.webp",
-					"color01": "#220070",
-					"color02": "#af76d5",
-					"alpha": 1,
-					"duration": 2500,
-					"life": 400
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.toll_the_dead.purple.skull_smoke",
-						"type": "mysteriouslights",
-						"color01": "#4c00ff",
-						"color02": "#ba9fd5",
-						"onCenter": true,
-						"rate": 15,
-						"alpha": 1,
-						"duration": 2200
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": true,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-3.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "generic",
-					"animation": "ui",
-					"variant": "horror",
-					"color": "darkteal",
-					"enableCustom": true,
-					"customPath": "jb2a.condition.curse.01.011.green"
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-2.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Cause Fear",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "655",
-			"label": "Create Magen",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 500,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_generic.slashing.two_handed"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Weapons/Melee_Slashing_Piercing/slashing-blood-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Create Magen",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "656",
-			"label": "Defensive Field",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldspell",
-					"animation": "complete",
-					"variant": "03",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-barrier-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"saturation": -1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Defensive Field",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "657",
-			"label": "Eldritch Cannon",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_attack.02.hammer.01"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 600,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
-					"repeat": 3,
-					"repeatDelay": 1000,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 3,
-					"repeatDelay": 1000,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Eldritch Cannon",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "658",
-			"label": "Elemental Bane",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.energy_attack.01.multicolored01"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-5.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Elemental Bane",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "659",
-			"label": "Encode Thoughts",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_12.webp",
-					"color01": "#da98ec",
-					"color02": "#0023d1",
-					"duration": 1500,
-					"onCenter": true,
-					"alpha": 1
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.magic_signs.rune.enchantment.complete.purple",
-						"type": "magicsphere",
-						"color01": "#bfedf3",
-						"color02": "#ff00f7",
-						"onCenter": true,
-						"rate": 5,
-						"alpha": 1,
-						"scale": 2,
-						"gravity": 1,
-						"duration": 3500,
-						"life": 1000
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Whoosh/*",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "shake",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"playbackRate": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "enchantment",
-					"variant": "runecomplete",
-					"color": "pink",
-					"enableCustom": true,
-					"customPath": "jb2a.energy_strands.02.marker.bluepurple"
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Encode Thoughts",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "660",
-			"label": "Flash of Genius",
-			"levels3d": {
-				"enable": true,
-				"type": "magicsphere",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/emberssmall.png",
-					"onCenter": true,
-					"alpha": 1,
-					"color01": "#007517",
-					"color02": "#9b06fe",
-					"rate": 5
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.ui.indicator.green.01.01",
-						"type": "mysteriouslights",
-						"color01": "#dfd007",
-						"color02": "#00fa81",
-						"alpha": 1,
-						"onCenter": true,
-						"rate": 25
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-2.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 800,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"tint": false,
-					"saturation": -1,
-					"contrast": 0.75,
-					"tintColor": "#ffffff"
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-1.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "energy",
-					"animation": "dodecahedron",
-					"variant": "rolled",
-					"color": "blue",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 2500,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 0.5,
-					"zIndex": 1,
-					"tint": false,
-					"tintColor": ""
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-3.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "icons/svg/light.svg"
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Flash of Genius",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "661",
-			"label": "Gift of Gab",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "generic",
-					"animation": "outpulse",
-					"variant": "01",
-					"color": "purplepink",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Bardic-Inspiration.ogg",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Gift of Gab",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "662",
-			"label": "Incite Greed",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.ioun_stones.01.purple.absorption"
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 800,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 3,
-					"repeatDelay": 3500,
-					"saturate": 0,
-					"size": 0.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "light",
-					"variant": "complete",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0.75,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 3,
-					"tint": true,
-					"tintColor": "#a382e7",
-					"zIndex": 1,
-					"saturation": -1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Incite Greed",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "663",
-			"label": "Infestation",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
-					"speed": 10,
-					"duration": 2000,
-					"life": 400,
-					"alpha": 1,
-					"onCenter": true,
-					"color01": "#ff9500",
-					"color02": "#beb7b7"
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.butterflies.many.bright_orange",
-						"type": "jb2aexplosionnolight",
-						"speed": 10,
-						"scale": 1,
-						"alpha": 1,
-						"onCenter": true,
-						"color01": "#d2cbcb",
-						"color02": "#dbce0f",
-						"duration": 2500,
-						"life": 400
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": true,
-					"sourceType": "swipe",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-swarm-3.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "particles",
-					"animation": "dots",
-					"variant": "03",
-					"color": "green",
-					"enableCustom": true,
-					"customPath": "jb2a.butterflies.many.orange"
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 2000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1.2,
-					"zIndex": 1,
-					"tint": true,
-					"tintColor": "#00ff55"
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.butterflies.many.orange"
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1,
-					"playbackRate": 3
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "conjuration",
-					"variant": "runecomplete",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 1000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 0.75,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"tint": true,
-					"tintColor": "#ae00ff"
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.butterflies.many.orange"
-				}
-			},
-			"metaData": {
-				"label": "Infestation",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "664",
-			"label": "Mass Polymorph",
-			"levels3d": {
-				"type": "castingsign",
-				"data": {
-					"color01": "#b2ff24",
-					"color02": "#f94b01",
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_06.webp",
-					"autoSize": true,
-					"alpha": 1,
-					"onCenter": true
-				},
-				"sound": {
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-growl-1.mp3"
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"color01": "#d4ff00",
-						"color02": "#2570e9",
-						"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_06.webp",
-						"autoSize": true,
-						"type": "explosion",
-						"alpha": 1,
-						"onCenter": true,
-						"rate": 25,
-						"duration": 1000
-					}
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				},
-				"enable": true
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "standard",
-					"variant": "02",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-mutate-growl-1.mp3",
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 7,
-					"repeatDelay": 1400,
-					"size": 1.25,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "darkyellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-long-2.mp3"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 2,
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Mass Polymorph",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "665",
-			"label": "Mental Prison",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "illusion",
-					"variant": "runecomplete",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-7.mp3"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "default",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "chains",
-					"animation": "diamond",
-					"variant": "complete",
-					"color": "purple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 500,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": false,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Mental Prison",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "666",
-			"label": "Motivational Speech",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "bardicinspiration",
-					"variant": "inspire",
-					"color": "purplepink",
-					"enableCustom": true,
-					"customPath": "jb2a.music_notations.treble_clef.purple"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": -1000,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "target",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "bardicinspiration",
-					"variant": "inspire",
-					"color": "purplepink",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hellish-Rebuke.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Motivational Speech",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "667",
-			"label": "Repair",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_attack.02.hammer.01"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 600,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
-					"repeat": 3,
-					"repeatDelay": 1000,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 3,
-					"repeatDelay": 1000,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Repair",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "668",
-			"label": "Spirit of Death",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
-					"color01": "#ff00a2",
-					"color02": "#2bff00",
-					"alpha": 1,
-					"onCenter": true
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_09.webp",
-						"type": "holy",
-						"color01": "#6c15ef",
-						"color02": "#60745d",
-						"alpha": 1,
-						"onCenter": false,
-						"speed": 15,
-						"rate": 26
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-short-5.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-2.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "necromancy",
-					"variant": "complete",
-					"color": "green",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Spirit of Death",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "669",
-			"label": "Steel Defender",
-			"levels3d": {
-				"type": "explosion",
-				"data": {
-					"color01": "#FFFFFF",
-					"color02": "#FFFFFF",
-					"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-				},
-				"sound": {
-					"enable": false
-				},
-				"secondary": {
-					"enable": false,
-					"data": {
-						"color01": "#FFFFFF",
-						"color02": "#FFFFFF",
-						"spritePath": "modules/levels-3d-preview/assets/particles/dust.png"
-					}
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.melee_attack.02.hammer.01"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 600,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Arcane-Lock.mp3",
-					"repeat": 3,
-					"repeatDelay": 1000,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 3,
-					"repeatDelay": 1000,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Steel Defender",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "670",
-			"label": "Warp Sense",
-			"levels3d": {
-				"enable": true,
-				"type": "castingsign",
-				"data": {
-					"autoSize": true,
-					"spritePath": "modules/levels-3d-preview/assets/particles/magiccircles/magic_circle_04.webp",
-					"alpha": 1,
-					"color01": "#00aaff",
-					"color02": "#a8f5f0"
-				},
-				"secondary": {
-					"enable": true,
-					"data": {
-						"autoSize": true,
-						"spritePath": "jb2a.magic_signs.circle.01.divination",
-						"type": "jb2aexplosion",
-						"onCenter": true,
-						"rate": 5,
-						"life": 700,
-						"alpha": 1,
-						"scale": 1
-					}
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-5.mp3",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"tokens": {
-					"enable": true,
-					"source": true,
-					"target": false,
-					"sourceType": "twirl",
-					"sourcePlay": "start",
-					"targetType": "shake",
-					"targetPlay": "end"
-				}
-			},
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "ontoken",
-			"primary": {
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": false,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-5.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "divination",
-					"variant": "01",
-					"color": "lightblue",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Warp Sense",
-				"menu": "ontoken",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
 		}
 	],
 	"templatefx": [
 		{
-			"id": "671",
+			"id": "670",
 			"label": "Abi-Dalzim's Horrid Wilting",
 			"macro": {
 				"enable": false,
@@ -147584,7 +147363,7 @@
 			}
 		},
 		{
-			"id": "672",
+			"id": "671",
 			"label": "Acid Breath",
 			"macro": {
 				"enable": false,
@@ -147763,7 +147542,7 @@
 			}
 		},
 		{
-			"id": "673",
+			"id": "672",
 			"label": "Acid Splash",
 			"macro": {
 				"enable": false,
@@ -147953,7 +147732,7 @@
 			}
 		},
 		{
-			"id": "674",
+			"id": "673",
 			"label": "Aganazzar's Scorcher",
 			"macro": {
 				"enable": false,
@@ -148129,7 +147908,7 @@
 			}
 		},
 		{
-			"id": "675",
+			"id": "674",
 			"label": "Alarm",
 			"macro": {
 				"enable": false,
@@ -148319,7 +148098,7 @@
 			}
 		},
 		{
-			"id": "676",
+			"id": "675",
 			"label": "Antipathy/Sympathy",
 			"macro": {
 				"enable": false,
@@ -148508,7 +148287,7 @@
 			}
 		},
 		{
-			"id": "677",
+			"id": "676",
 			"label": "Arms of Hadar",
 			"macro": {
 				"enable": false,
@@ -148695,6 +148474,196 @@
 				"name": "5e Animations",
 				"moduleVersion": "2.0.0",
 				"version": 1740566308510
+			}
+		},
+		{
+			"id": "677",
+			"label": "Aura of Annihilation",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "calllightning",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.template_circle.aura.01.loop.large.bluepurple"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 0.5,
+					"persistent": true,
+					"persistType": "attachtemplate",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1.25",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Aura of Annihilation",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
 			}
 		},
 		{
@@ -151942,6 +151911,205 @@
 		},
 		{
 			"id": "696",
+			"label": "Control Flames",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "calllightning",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.flames.01.orange"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-flamethrower-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": true,
+					"persistType": "attachtemplate",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "2.5",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Control Flames",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "697",
 			"label": "Control Water",
 			"macro": {
 				"enable": false,
@@ -152132,7 +152300,7 @@
 			}
 		},
 		{
-			"id": "697",
+			"id": "698",
 			"label": "Control Weather",
 			"macro": {
 				"enable": false,
@@ -152308,7 +152476,7 @@
 			}
 		},
 		{
-			"id": "698",
+			"id": "699",
 			"label": "Control Winds",
 			"macro": {
 				"enable": false,
@@ -152498,7 +152666,7 @@
 			}
 		},
 		{
-			"id": "699",
+			"id": "700",
 			"label": "Create Bonfire",
 			"macro": {
 				"enable": false,
@@ -152688,7 +152856,7 @@
 			}
 		},
 		{
-			"id": "700",
+			"id": "701",
 			"label": "Create or Destroy Water",
 			"macro": {
 				"enable": false,
@@ -152864,7 +153032,7 @@
 			}
 		},
 		{
-			"id": "701",
+			"id": "702",
 			"label": "Creation",
 			"macro": {
 				"enable": false,
@@ -153039,7 +153207,7 @@
 			}
 		},
 		{
-			"id": "702",
+			"id": "703",
 			"label": "Darkness",
 			"macro": {
 				"enable": false,
@@ -153215,7 +153383,7 @@
 			}
 		},
 		{
-			"id": "703",
+			"id": "704",
 			"label": "Dawn",
 			"macro": {
 				"enable": false,
@@ -153391,7 +153559,7 @@
 			}
 		},
 		{
-			"id": "704",
+			"id": "705",
 			"label": "Daylight",
 			"macro": {
 				"enable": false,
@@ -153569,7 +153737,7 @@
 			}
 		},
 		{
-			"id": "705",
+			"id": "706",
 			"label": "Destructive Wave",
 			"macro": {
 				"enable": false,
@@ -153745,7 +153913,387 @@
 			}
 		},
 		{
-			"id": "706",
+			"id": "707",
+			"label": "Detonate Eldritch Cannon",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "explosion",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Explosion/explosion-echo-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Detonate Eldritch Cannon",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "708",
+			"label": "Distort Value",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "calllightning",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.glint.yellow.many"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": true,
+					"persistType": "attachtemplate",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "5",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Distort Value",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "709",
 			"label": "Draconic Transformation",
 			"macro": {
 				"enable": false,
@@ -153935,7 +154483,7 @@
 			}
 		},
 		{
-			"id": "707",
+			"id": "710",
 			"label": "Dragon's Breath",
 			"macro": {
 				"enable": false,
@@ -154125,7 +154673,7 @@
 			}
 		},
 		{
-			"id": "708",
+			"id": "711",
 			"label": "Dust Devil",
 			"macro": {
 				"enable": false,
@@ -154315,7 +154863,7 @@
 			}
 		},
 		{
-			"id": "709",
+			"id": "712",
 			"label": "Earthquake",
 			"macro": {
 				"enable": false,
@@ -154492,7 +155040,7 @@
 			}
 		},
 		{
-			"id": "710",
+			"id": "713",
 			"label": "Elemental Burst",
 			"macro": {
 				"enable": false,
@@ -154682,7 +155230,7 @@
 			}
 		},
 		{
-			"id": "711",
+			"id": "714",
 			"label": "Elementalism",
 			"macro": {
 				"enable": false,
@@ -154872,7 +155420,7 @@
 			}
 		},
 		{
-			"id": "712",
+			"id": "715",
 			"label": "Entangle",
 			"macro": {
 				"enable": false,
@@ -155048,7 +155596,7 @@
 			}
 		},
 		{
-			"id": "713",
+			"id": "716",
 			"label": "Erupting Earth",
 			"macro": {
 				"enable": false,
@@ -155238,7 +155786,7 @@
 			}
 		},
 		{
-			"id": "714",
+			"id": "717",
 			"label": "Fabricate",
 			"macro": {
 				"enable": false,
@@ -155428,7 +155976,7 @@
 			}
 		},
 		{
-			"id": "715",
+			"id": "718",
 			"label": "Faerie Fire",
 			"macro": {
 				"enable": false,
@@ -155618,7 +156166,7 @@
 			}
 		},
 		{
-			"id": "716",
+			"id": "719",
 			"label": "Fear",
 			"macro": {
 				"enable": false,
@@ -155796,7 +156344,7 @@
 			}
 		},
 		{
-			"id": "717",
+			"id": "720",
 			"label": "Fire Breath",
 			"macro": {
 				"enable": false,
@@ -155975,7 +156523,7 @@
 			}
 		},
 		{
-			"id": "718",
+			"id": "721",
 			"label": "Fire Storm",
 			"macro": {
 				"enable": false,
@@ -156149,7 +156697,7 @@
 			}
 		},
 		{
-			"id": "719",
+			"id": "722",
 			"label": "Flame Strike",
 			"macro": {
 				"enable": false,
@@ -156325,7 +156873,197 @@
 			}
 		},
 		{
-			"id": "720",
+			"id": "723",
+			"label": "Flamethrower",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "cone",
+					"animation": "breathweapon",
+					"variant": "fire01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.breath_weapons02.burst.cone.fire.orange.01"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-flamethrower-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 2000,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Flamethrower",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "724",
 			"label": "Flaming Sphere",
 			"macro": {
 				"enable": false,
@@ -156501,7 +157239,7 @@
 			}
 		},
 		{
-			"id": "721",
+			"id": "725",
 			"label": "Fog Cloud",
 			"macro": {
 				"enable": false,
@@ -156677,7 +157415,7 @@
 			}
 		},
 		{
-			"id": "722",
+			"id": "726",
 			"label": "Forcecage",
 			"macro": {
 				"enable": false,
@@ -156867,7 +157605,373 @@
 			}
 		},
 		{
-			"id": "723",
+			"id": "727",
+			"label": "Frost Fingers",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0,
+					"occlusionMode": 0,
+					"opacity": 0.75,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"rotate": 0,
+					"scale": "1, 1",
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "psfx.5th-level-spells.cone-of-cold.v1.001",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "cone",
+					"animation": "coneofcold",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 500,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"metaData": {
+				"label": "Frost Fingers",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "728",
+			"label": "Gate Seal",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "magicsign",
+					"variant": "abjuration",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-ticking-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": true,
+					"persistType": "attachtemplate",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Gate Seal",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "729",
 			"label": "Globe of Invulnerability",
 			"macro": {
 				"enable": false,
@@ -157044,7 +158148,7 @@
 			}
 		},
 		{
-			"id": "724",
+			"id": "730",
 			"label": "Grease",
 			"macro": {
 				"enable": false,
@@ -157221,7 +158325,7 @@
 			}
 		},
 		{
-			"id": "725",
+			"id": "731",
 			"label": "Gust of Wind",
 			"macro": {
 				"enable": false,
@@ -157397,7 +158501,7 @@
 			}
 		},
 		{
-			"id": "726",
+			"id": "732",
 			"label": "Hail of Thorns",
 			"macro": {
 				"enable": false,
@@ -157586,7 +158690,7 @@
 			}
 		},
 		{
-			"id": "727",
+			"id": "733",
 			"label": "Hallow",
 			"macro": {
 				"enable": false,
@@ -157763,7 +158867,7 @@
 			}
 		},
 		{
-			"id": "728",
+			"id": "734",
 			"label": "Hallucinatory Terrain",
 			"macro": {
 				"enable": false,
@@ -157938,7 +159042,7 @@
 			}
 		},
 		{
-			"id": "729",
+			"id": "735",
 			"label": "Healing Spirit",
 			"macro": {
 				"enable": false,
@@ -158115,7 +159219,7 @@
 			}
 		},
 		{
-			"id": "730",
+			"id": "736",
 			"label": "Heroes' Feast",
 			"macro": {
 				"enable": false,
@@ -158305,7 +159409,7 @@
 			}
 		},
 		{
-			"id": "731",
+			"id": "737",
 			"label": "Hunger of Hadar",
 			"macro": {
 				"enable": false,
@@ -158481,7 +159585,7 @@
 			}
 		},
 		{
-			"id": "732",
+			"id": "738",
 			"label": "Hypnotic Pattern",
 			"macro": {
 				"enable": false,
@@ -158660,7 +159764,7 @@
 			}
 		},
 		{
-			"id": "733",
+			"id": "739",
 			"label": "Ice Knife",
 			"macro": {
 				"enable": false,
@@ -158850,7 +159954,7 @@
 			}
 		},
 		{
-			"id": "734",
+			"id": "740",
 			"label": "Ice Storm",
 			"macro": {
 				"enable": false,
@@ -159026,7 +160130,7 @@
 			}
 		},
 		{
-			"id": "735",
+			"id": "741",
 			"label": "Image",
 			"macro": {
 				"enable": false,
@@ -159202,7 +160306,7 @@
 			}
 		},
 		{
-			"id": "736",
+			"id": "742",
 			"label": "Incendiary Cloud",
 			"macro": {
 				"enable": false,
@@ -159378,7 +160482,7 @@
 			}
 		},
 		{
-			"id": "737",
+			"id": "743",
 			"label": "Insect Plague",
 			"macro": {
 				"enable": false,
@@ -159553,7 +160657,7 @@
 			}
 		},
 		{
-			"id": "738",
+			"id": "744",
 			"label": "Investiture of Flame",
 			"macro": {
 				"enable": false,
@@ -159743,7 +160847,7 @@
 			}
 		},
 		{
-			"id": "739",
+			"id": "745",
 			"label": "Investiture of Ice",
 			"macro": {
 				"enable": false,
@@ -159933,7 +161037,7 @@
 			}
 		},
 		{
-			"id": "740",
+			"id": "746",
 			"label": "Investiture of Stone",
 			"macro": {
 				"enable": false,
@@ -160123,7 +161227,7 @@
 			}
 		},
 		{
-			"id": "741",
+			"id": "747",
 			"label": "Investiture of Wind",
 			"macro": {
 				"enable": false,
@@ -160313,7 +161417,7 @@
 			}
 		},
 		{
-			"id": "742",
+			"id": "748",
 			"label": "Land's Aid",
 			"macro": {
 				"enable": false,
@@ -160503,7 +161607,7 @@
 			}
 		},
 		{
-			"id": "743",
+			"id": "749",
 			"label": "Lightning Bolt",
 			"macro": {
 				"enable": false,
@@ -160680,7 +161784,7 @@
 			}
 		},
 		{
-			"id": "744",
+			"id": "750",
 			"label": "Lightning Breath",
 			"macro": {
 				"enable": false,
@@ -160859,7 +161963,7 @@
 			}
 		},
 		{
-			"id": "745",
+			"id": "751",
 			"label": "Magic Circle",
 			"macro": {
 				"enable": false,
@@ -161035,7 +162139,7 @@
 			}
 		},
 		{
-			"id": "746",
+			"id": "752",
 			"label": "Mass Cure Wounds",
 			"macro": {
 				"enable": false,
@@ -161226,7 +162330,7 @@
 			}
 		},
 		{
-			"id": "747",
+			"id": "753",
 			"label": "Maximilian's Earthen Grasp",
 			"macro": {
 				"enable": false,
@@ -161416,7 +162520,7 @@
 			}
 		},
 		{
-			"id": "748",
+			"id": "754",
 			"label": "Meteor Swarm",
 			"macro": {
 				"enable": false,
@@ -161606,7 +162710,7 @@
 			}
 		},
 		{
-			"id": "749",
+			"id": "755",
 			"label": "Mind Blast",
 			"macro": {
 				"enable": false,
@@ -161781,7 +162885,7 @@
 			}
 		},
 		{
-			"id": "750",
+			"id": "756",
 			"label": "Minor Illusion",
 			"macro": {
 				"enable": false,
@@ -161971,7 +163075,7 @@
 			}
 		},
 		{
-			"id": "751",
+			"id": "757",
 			"label": "Mirage Arcane",
 			"macro": {
 				"enable": false,
@@ -162146,7 +163250,7 @@
 			}
 		},
 		{
-			"id": "752",
+			"id": "758",
 			"label": "Misty Escape",
 			"macro": {
 				"enable": false,
@@ -162336,7 +163440,7 @@
 			}
 		},
 		{
-			"id": "753",
+			"id": "759",
 			"label": "Mold Earth",
 			"macro": {
 				"enable": false,
@@ -162526,7 +163630,7 @@
 			}
 		},
 		{
-			"id": "754",
+			"id": "760",
 			"label": "Moonbeam",
 			"macro": {
 				"enable": false,
@@ -162702,7 +163806,7 @@
 			}
 		},
 		{
-			"id": "755",
+			"id": "761",
 			"label": "Move Earth",
 			"macro": {
 				"enable": false,
@@ -162877,7 +163981,7 @@
 			}
 		},
 		{
-			"id": "756",
+			"id": "762",
 			"label": "Nathair's Mischief",
 			"macro": {
 				"enable": false,
@@ -163067,7 +164171,7 @@
 			}
 		},
 		{
-			"id": "757",
+			"id": "763",
 			"label": "Paralyzing Breath",
 			"macro": {
 				"enable": false,
@@ -163245,7 +164349,7 @@
 			}
 		},
 		{
-			"id": "758",
+			"id": "764",
 			"label": "Phantasmal Force",
 			"macro": {
 				"enable": false,
@@ -163421,7 +164525,7 @@
 			}
 		},
 		{
-			"id": "759",
+			"id": "765",
 			"label": "Plant Growth",
 			"macro": {
 				"enable": false,
@@ -163612,7 +164716,7 @@
 			}
 		},
 		{
-			"id": "760",
+			"id": "766",
 			"label": "Poison Breath",
 			"macro": {
 				"enable": false,
@@ -163790,7 +164894,7 @@
 			}
 		},
 		{
-			"id": "761",
+			"id": "767",
 			"label": "Prismatic Spray",
 			"macro": {
 				"enable": false,
@@ -163965,7 +165069,7 @@
 			}
 		},
 		{
-			"id": "762",
+			"id": "768",
 			"label": "Prismatic Wall",
 			"macro": {
 				"enable": false,
@@ -164158,7 +165262,7 @@
 			}
 		},
 		{
-			"id": "763",
+			"id": "769",
 			"label": "Private Sanctum",
 			"macro": {
 				"enable": false,
@@ -164348,7 +165452,7 @@
 			}
 		},
 		{
-			"id": "764",
+			"id": "770",
 			"label": "Programmed Illusion",
 			"macro": {
 				"enable": false,
@@ -164523,7 +165627,197 @@
 			}
 		},
 		{
-			"id": "765",
+			"id": "771",
+			"label": "Protector",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "outpulse",
+					"variant": "02",
+					"color": "whiteblue",
+					"enableCustom": true,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0.5,
+					"occlusionMode": "3",
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "sequencerground",
+					"playbackRate": 1,
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"rotate": 0,
+					"saturate": 0,
+					"scale": "1",
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Protector",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "772",
 			"label": "Purify Food and Drink",
 			"macro": {
 				"enable": false,
@@ -164699,7 +165993,7 @@
 			}
 		},
 		{
-			"id": "766",
+			"id": "773",
 			"label": "Pyrotechnics",
 			"macro": {
 				"enable": false,
@@ -164889,7 +166183,7 @@
 			}
 		},
 		{
-			"id": "767",
+			"id": "774",
 			"label": "Radiance of the Dawn",
 			"macro": {
 				"enable": false,
@@ -165079,7 +166373,7 @@
 			}
 		},
 		{
-			"id": "768",
+			"id": "775",
 			"label": "Repulsion Breath",
 			"macro": {
 				"enable": false,
@@ -165257,7 +166551,7 @@
 			}
 		},
 		{
-			"id": "769",
+			"id": "776",
 			"label": "Reverse Gravity",
 			"macro": {
 				"enable": false,
@@ -165447,7 +166741,7 @@
 			}
 		},
 		{
-			"id": "770",
+			"id": "777",
 			"label": "Rime's Binding Ice",
 			"macro": {
 				"enable": false,
@@ -165623,7 +166917,7 @@
 			}
 		},
 		{
-			"id": "771",
+			"id": "778",
 			"label": "Shape Water",
 			"macro": {
 				"enable": false,
@@ -165813,7 +167107,7 @@
 			}
 		},
 		{
-			"id": "772",
+			"id": "779",
 			"label": "Shatter",
 			"macro": {
 				"enable": false,
@@ -165989,7 +167283,7 @@
 			}
 		},
 		{
-			"id": "773",
+			"id": "780",
 			"label": "Sickening Radiance",
 			"macro": {
 				"enable": false,
@@ -166165,7 +167459,7 @@
 			}
 		},
 		{
-			"id": "774",
+			"id": "781",
 			"label": "Silence",
 			"macro": {
 				"enable": false,
@@ -166342,7 +167636,7 @@
 			}
 		},
 		{
-			"id": "775",
+			"id": "782",
 			"label": "Sleet Storm",
 			"macro": {
 				"enable": false,
@@ -166518,7 +167812,7 @@
 			}
 		},
 		{
-			"id": "776",
+			"id": "783",
 			"label": "Slow",
 			"macro": {
 				"enable": false,
@@ -166693,7 +167987,7 @@
 			}
 		},
 		{
-			"id": "777",
+			"id": "784",
 			"label": "Slowing Breath",
 			"macro": {
 				"enable": false,
@@ -166871,7 +168165,7 @@
 			}
 		},
 		{
-			"id": "778",
+			"id": "785",
 			"label": "Spike Growth",
 			"macro": {
 				"enable": false,
@@ -167048,7 +168342,7 @@
 			}
 		},
 		{
-			"id": "779",
+			"id": "786",
 			"label": "Spiritual Weapon",
 			"macro": {
 				"enable": false,
@@ -167249,7 +168543,7 @@
 			}
 		},
 		{
-			"id": "780",
+			"id": "787",
 			"label": "Stinking Cloud",
 			"macro": {
 				"enable": false,
@@ -167425,7 +168719,7 @@
 			}
 		},
 		{
-			"id": "781",
+			"id": "788",
 			"label": "Storm of Radiance",
 			"macro": {
 				"enable": false,
@@ -167616,7 +168910,7 @@
 			}
 		},
 		{
-			"id": "782",
+			"id": "789",
 			"label": "Storm of Vengeance",
 			"macro": {
 				"enable": false,
@@ -167805,7 +169099,7 @@
 			}
 		},
 		{
-			"id": "783",
+			"id": "790",
 			"label": "Storm Sphere",
 			"macro": {
 				"enable": false,
@@ -167981,7 +169275,7 @@
 			}
 		},
 		{
-			"id": "784",
+			"id": "791",
 			"label": "Sunbeam",
 			"macro": {
 				"enable": false,
@@ -168161,7 +169455,7 @@
 			}
 		},
 		{
-			"id": "785",
+			"id": "792",
 			"label": "Sunburst",
 			"macro": {
 				"enable": false,
@@ -168338,7 +169632,7 @@
 			}
 		},
 		{
-			"id": "786",
+			"id": "793",
 			"label": "Sword Burst",
 			"macro": {
 				"enable": false,
@@ -168528,7 +169822,7 @@
 			}
 		},
 		{
-			"id": "787",
+			"id": "794",
 			"label": "Symbol",
 			"macro": {
 				"enable": false,
@@ -168718,7 +170012,7 @@
 			}
 		},
 		{
-			"id": "788",
+			"id": "795",
 			"label": "Synaptic Static",
 			"macro": {
 				"enable": false,
@@ -168894,7 +170188,7 @@
 			}
 		},
 		{
-			"id": "789",
+			"id": "796",
 			"label": "Teleportation Circle",
 			"macro": {
 				"enable": false,
@@ -169069,7 +170363,7 @@
 			}
 		},
 		{
-			"id": "790",
+			"id": "797",
 			"label": "Tidal Wave",
 			"macro": {
 				"enable": false,
@@ -169260,7 +170554,7 @@
 			}
 		},
 		{
-			"id": "791",
+			"id": "798",
 			"label": "Tiny Hut",
 			"macro": {
 				"enable": false,
@@ -169438,7 +170732,7 @@
 			}
 		},
 		{
-			"id": "792",
+			"id": "799",
 			"label": "Transmute Rock",
 			"macro": {
 				"enable": false,
@@ -169629,7 +170923,7 @@
 			}
 		},
 		{
-			"id": "793",
+			"id": "800",
 			"label": "Tsunami",
 			"macro": {
 				"enable": false,
@@ -169820,7 +171114,7 @@
 			}
 		},
 		{
-			"id": "794",
+			"id": "801",
 			"label": "Wall of Fire",
 			"macro": {
 				"enable": false,
@@ -169998,7 +171292,7 @@
 			}
 		},
 		{
-			"id": "795",
+			"id": "802",
 			"label": "Wall of Force",
 			"macro": {
 				"enable": false,
@@ -170189,7 +171483,7 @@
 			}
 		},
 		{
-			"id": "796",
+			"id": "803",
 			"label": "Wall of Ice",
 			"macro": {
 				"enable": false,
@@ -170379,7 +171673,7 @@
 			}
 		},
 		{
-			"id": "797",
+			"id": "804",
 			"label": "Wall of Light",
 			"macro": {
 				"enable": false,
@@ -170572,7 +171866,7 @@
 			}
 		},
 		{
-			"id": "798",
+			"id": "805",
 			"label": "Wall of Sand",
 			"macro": {
 				"enable": false,
@@ -170762,7 +172056,7 @@
 			}
 		},
 		{
-			"id": "799",
+			"id": "806",
 			"label": "Wall of Stone",
 			"macro": {
 				"enable": false,
@@ -170952,7 +172246,7 @@
 			}
 		},
 		{
-			"id": "800",
+			"id": "807",
 			"label": "Wall of Thorns",
 			"macro": {
 				"enable": false,
@@ -171142,7 +172436,7 @@
 			}
 		},
 		{
-			"id": "801",
+			"id": "808",
 			"label": "Wall of Water",
 			"macro": {
 				"enable": false,
@@ -171332,7 +172626,7 @@
 			}
 		},
 		{
-			"id": "802",
+			"id": "809",
 			"label": "Warding Wind",
 			"macro": {
 				"enable": false,
@@ -171522,7 +172816,7 @@
 			}
 		},
 		{
-			"id": "803",
+			"id": "810",
 			"label": "Warping Implosion",
 			"macro": {
 				"enable": false,
@@ -171712,7 +173006,7 @@
 			}
 		},
 		{
-			"id": "804",
+			"id": "811",
 			"label": "Watery Sphere",
 			"macro": {
 				"enable": false,
@@ -171902,7 +173196,7 @@
 			}
 		},
 		{
-			"id": "805",
+			"id": "812",
 			"label": "Weakening Breath",
 			"macro": {
 				"enable": false,
@@ -172080,7 +173374,7 @@
 			}
 		},
 		{
-			"id": "806",
+			"id": "813",
 			"label": "Web",
 			"macro": {
 				"enable": false,
@@ -172256,7 +173550,7 @@
 			}
 		},
 		{
-			"id": "807",
+			"id": "814",
 			"label": "Weird",
 			"macro": {
 				"enable": false,
@@ -172445,7 +173739,7 @@
 			}
 		},
 		{
-			"id": "808",
+			"id": "815",
 			"label": "Whirlwind",
 			"macro": {
 				"enable": false,
@@ -172635,7 +173929,7 @@
 			}
 		},
 		{
-			"id": "809",
+			"id": "816",
 			"label": "Wind Wall",
 			"macro": {
 				"enable": false,
@@ -172812,7 +174106,185 @@
 			}
 		},
 		{
-			"id": "810",
+			"id": "817",
+			"label": "Wither and Bloom",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "templatefx",
+			"primary": {
+				"options": {
+					"delay": 0,
+					"elevation": 1000,
+					"isMasked": false,
+					"isWait": false,
+					"occlusionAlpha": 0,
+					"occlusionMode": 0,
+					"opacity": 1,
+					"persistent": false,
+					"persistType": "attachtemplate",
+					"removeTemplate": false,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"rotate": 0,
+					"scale": "1, 1",
+					"zIndex": 0,
+					"tint": true,
+					"tintColor": "#00ff00"
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-1.mp3",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "templatefx",
+					"menuType": "circle",
+					"animation": "outpulse",
+					"variant": "02",
+					"color": "yellowwhite",
+					"enableCustom": false
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 250,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 0,
+					"size": 1.5,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"startTime": 0,
+					"volume": 0.75,
+					"repeat": 1,
+					"repeatDelay": 250
+				}
+			},
+			"source": {
+				"enable": false,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": false,
+					"file": "",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				}
+			},
+			"target": {
+				"enable": true,
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isWait": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"delay": 0,
+					"enable": true,
+					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
+					"startTime": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"volume": 0.75
+				},
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.energy_strands.overlay.dark_green.01"
+				}
+			},
+			"metaData": {
+				"label": "Wither and Bloom",
+				"menu": "templatefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "818",
 			"label": "Word of Radiance",
 			"macro": {
 				"enable": false,
@@ -173002,7 +174474,7 @@
 			}
 		},
 		{
-			"id": "811",
+			"id": "819",
 			"label": "Wrath of Nature",
 			"macro": {
 				"enable": false,
@@ -173192,7 +174664,7 @@
 			}
 		},
 		{
-			"id": "812",
+			"id": "820",
 			"label": "Wrath of the Sea",
 			"macro": {
 				"enable": false,
@@ -173382,7 +174854,7 @@
 			}
 		},
 		{
-			"id": "813",
+			"id": "821",
 			"label": "Zone of Truth",
 			"macro": {
 				"enable": false,
@@ -173555,1509 +175027,6 @@
 				"name": "5e Animations",
 				"moduleVersion": "2.0.0",
 				"version": 5
-			}
-		},
-		{
-			"id": "814",
-			"label": "Control Flames",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "calllightning",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.flames.01.orange"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-flamethrower-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0.5,
-					"occlusionMode": "3",
-					"opacity": 1,
-					"persistent": true,
-					"persistType": "attachtemplate",
-					"playbackRate": 1,
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"rotate": 0,
-					"saturate": 0,
-					"scale": "2.5",
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": false,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Control Flames",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "815",
-			"label": "Detonate Eldritch Cannon",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "explosion",
-					"variant": "01",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Explosion/explosion-echo-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0.5,
-					"occlusionMode": "3",
-					"opacity": 1,
-					"persistent": false,
-					"persistType": "sequencerground",
-					"playbackRate": 1,
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"rotate": 0,
-					"saturate": 0,
-					"scale": "1",
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Detonate Eldritch Cannon",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "816",
-			"label": "Distort Value",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "calllightning",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.glint.yellow.many"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-lively-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0.5,
-					"occlusionMode": "3",
-					"opacity": 1,
-					"persistent": true,
-					"persistType": "attachtemplate",
-					"playbackRate": 1,
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"rotate": 0,
-					"saturate": 0,
-					"scale": "5",
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Distort Value",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "817",
-			"label": "Flamethrower",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "cone",
-					"animation": "breathweapon",
-					"variant": "fire01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.breath_weapons02.burst.cone.fire.orange.01"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-flamethrower-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 2000,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0.5,
-					"occlusionMode": "3",
-					"opacity": 1,
-					"persistent": false,
-					"persistType": "sequencerground",
-					"playbackRate": 1,
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"rotate": 0,
-					"saturate": 0,
-					"scale": "1",
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Flamethrower",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "818",
-			"label": "Frost Fingers",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"options": {
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0,
-					"occlusionMode": 0,
-					"opacity": 0.75,
-					"persistent": false,
-					"persistType": "sequencerground",
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 500,
-					"rotate": 0,
-					"scale": "1, 1",
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "psfx.5th-level-spells.cone-of-cold.v1.001",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "cone",
-					"animation": "coneofcold",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 500,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"metaData": {
-				"label": "Frost Fingers",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "819",
-			"label": "Gate Seal",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "magicsign",
-					"variant": "abjuration",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-decrescendo-ticking-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0.5,
-					"occlusionMode": "3",
-					"opacity": 1,
-					"persistent": true,
-					"persistType": "attachtemplate",
-					"playbackRate": 1,
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"rotate": 0,
-					"saturate": 0,
-					"scale": "1",
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Gate Seal",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "820",
-			"label": "Protector",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "outpulse",
-					"variant": "02",
-					"color": "whiteblue",
-					"enableCustom": true,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0.5,
-					"occlusionMode": "3",
-					"opacity": 1,
-					"persistent": false,
-					"persistType": "sequencerground",
-					"playbackRate": 1,
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"rotate": 0,
-					"saturate": 0,
-					"scale": "1",
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Protector",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "821",
-			"label": "Wither and Bloom",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "templatefx",
-			"primary": {
-				"options": {
-					"delay": 0,
-					"elevation": 1000,
-					"isMasked": false,
-					"isWait": false,
-					"occlusionAlpha": 0,
-					"occlusionMode": 0,
-					"opacity": 1,
-					"persistent": false,
-					"persistType": "attachtemplate",
-					"removeTemplate": false,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"rotate": 0,
-					"scale": "1, 1",
-					"zIndex": 0,
-					"tint": true,
-					"tintColor": "#00ff00"
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Ray/spell-ray-1.mp3",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "templatefx",
-					"menuType": "circle",
-					"animation": "outpulse",
-					"variant": "02",
-					"color": "yellowwhite",
-					"enableCustom": false
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 250,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 0,
-					"size": 1.5,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"startTime": 0,
-					"volume": 0.75,
-					"repeat": 1,
-					"repeatDelay": 250
-				}
-			},
-			"source": {
-				"enable": false,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": false,
-					"file": "",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				}
-			},
-			"target": {
-				"enable": true,
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isWait": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"delay": 0,
-					"enable": true,
-					"file": "psfx.1st-level-spells.cure-wounds.v1.001",
-					"startTime": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"volume": 0.75
-				},
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.energy_strands.overlay.dark_green.01"
-				}
-			},
-			"metaData": {
-				"label": "Wither and Bloom",
-				"menu": "templatefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
 			}
 		}
 	],
@@ -176265,6 +176234,205 @@
 		{
 			"id": "831",
 			"data": {
+				"projectile": {
+					"dbSection": "range",
+					"menuType": "spell",
+					"animation": "fireballbeam",
+					"variant": "01",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": "",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"removeTemplate": false,
+						"wait": -1800
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 1,
+						"file": "psfx.3rd-level-spells.fireball.v1.001.beam"
+					}
+				},
+				"preExplosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"enable": false,
+					"sound": {
+						"enable": false,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75
+					}
+				},
+				"explosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "fireball",
+					"variant": "explode",
+					"color": "orange",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1.25,
+						"wait": -1000,
+						"aboveTemplate": false
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 1,
+						"file": "psfx.3rd-level-spells.fireball.v1.001.explosion"
+					}
+				},
+				"afterImage": {
+					"enable": false,
+					"customPath": "",
+					"options": {
+						"elevation": 0,
+						"persistent": false,
+						"scale": 1
+					}
+				}
+			},
+			"label": "Fireball",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "proToTemp",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": true,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Fireball",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "832",
+			"data": {
 				"start": {
 					"dbSection": "static",
 					"enabe": true,
@@ -176367,7 +176535,7 @@
 			}
 		},
 		{
-			"id": "832",
+			"id": "833",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -176568,7 +176736,7 @@
 			}
 		},
 		{
-			"id": "833",
+			"id": "834",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -176765,7 +176933,7 @@
 			}
 		},
 		{
-			"id": "834",
+			"id": "835",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -176954,7 +177122,7 @@
 			}
 		},
 		{
-			"id": "835",
+			"id": "836",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -177064,7 +177232,7 @@
 			}
 		},
 		{
-			"id": "836",
+			"id": "837",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -177169,7 +177337,7 @@
 			}
 		},
 		{
-			"id": "837",
+			"id": "838",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -177273,7 +177441,7 @@
 			}
 		},
 		{
-			"id": "838",
+			"id": "839",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -177372,7 +177540,7 @@
 			}
 		},
 		{
-			"id": "839",
+			"id": "840",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -177471,7 +177639,7 @@
 			}
 		},
 		{
-			"id": "840",
+			"id": "841",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -177668,7 +177836,407 @@
 			}
 		},
 		{
-			"id": "841",
+			"id": "842",
+			"data": {
+				"projectile": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "snowball",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": false,
+					"customPath": "",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 5,
+						"repeatDelay": 250,
+						"removeTemplate": false,
+						"wait": -1800
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-1.mp3"
+					}
+				},
+				"preExplosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"enable": false,
+					"sound": {
+						"enable": false,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75
+					}
+				},
+				"explosion": {
+					"dbSection": "static",
+					"menuType": "ice",
+					"animation": "snowflake",
+					"variant": "01",
+					"color": "whiteblue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1.25,
+						"wait": -1000,
+						"aboveTemplate": false
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-blast-1.mp3"
+					}
+				},
+				"afterImage": {
+					"enable": false,
+					"customPath": "",
+					"options": {
+						"elevation": 0,
+						"persistent": false,
+						"scale": 1
+					}
+				}
+			},
+			"label": "Snilloc's Snowball Swarm",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "proToTemp",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Snilloc's Snowball Swarm",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "843",
+			"data": {
+				"projectile": {
+					"dbSection": "range",
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "physical",
+					"color": "orange",
+					"enableCustom": true,
+					"customPath": "jb2a.ranged.card.01.projectile.01.yellow",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 30,
+						"repeatDelay": 125,
+						"removeTemplate": false,
+						"wait": 0,
+						"randomOffset": true
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 10,
+						"repeatDelay": 350,
+						"startTime": 500,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Weapons/Ranged_Arrow_Impact/arrow-impact-7.mp3"
+					}
+				},
+				"preExplosion": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"enable": false,
+					"sound": {
+						"enable": false,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 0,
+						"volume": 0.75
+					}
+				},
+				"explosion": {
+					"dbSection": "static",
+					"menuType": "generic",
+					"animation": "impact",
+					"variant": "01",
+					"color": "orange",
+					"options": {
+						"elevation": 1000,
+						"opacity": 1,
+						"playbackRate": 1,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"scale": 1,
+						"wait": 0
+					},
+					"sound": {
+						"enable": true,
+						"delay": 0,
+						"repeat": 1,
+						"repeatDelay": 250,
+						"startTime": 500,
+						"volume": 0.75,
+						"file": "modules/dnd5e-animations/assets/sounds/Weapons/Ranged_Arrow_Impact/arrow-impact-7.mp3"
+					},
+					"enableCustom": true,
+					"customPath": "jb2a.ranged.card.01.projectile.01.yellow"
+				},
+				"afterImage": {
+					"enable": false,
+					"customPath": "",
+					"options": {
+						"elevation": 0,
+						"persistent": false,
+						"scale": 1
+					}
+				}
+			},
+			"label": "Spray of Cards",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "proToTemp",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1.5,
+					"zIndex": 1
+				}
+			},
+			"target": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"opacity": 1,
+					"persistent": false,
+					"repeat": 10,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Spray of Cards",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "844",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -177777,7 +178345,7 @@
 			}
 		},
 		{
-			"id": "842",
+			"id": "845",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -177881,7 +178449,7 @@
 			}
 		},
 		{
-			"id": "843",
+			"id": "846",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -177991,7 +178559,7 @@
 			}
 		},
 		{
-			"id": "844",
+			"id": "847",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -178100,7 +178668,7 @@
 			}
 		},
 		{
-			"id": "845",
+			"id": "848",
 			"data": {
 				"options": {
 					"alpha": 0.01,
@@ -178209,7 +178777,7 @@
 			}
 		},
 		{
-			"id": "846",
+			"id": "849",
 			"data": {
 				"video": {
 					"dbSection": "static",
@@ -178266,7 +178834,7 @@
 			}
 		},
 		{
-			"id": "847",
+			"id": "850",
 			"macro": {
 				"enable": false,
 				"playWhen": "0"
@@ -178325,7 +178893,7 @@
 			}
 		},
 		{
-			"id": "848",
+			"id": "851",
 			"data": {
 				"start": {
 					"dbSection": "static",
@@ -178424,7 +178992,112 @@
 			}
 		},
 		{
-			"id": "849",
+			"id": "852",
+			"data": {
+				"start": {
+					"dbSection": "static",
+					"enabe": true,
+					"menuType": "spell",
+					"animation": "mistystep",
+					"variant": "01",
+					"color": "blue",
+					"options": {
+						"delay": 0,
+						"elevation": 1000,
+						"fadeIn": 250,
+						"fadeOut": 250,
+						"isMasked": false,
+						"opacity": 1,
+						"isRadius": false,
+						"playbackRate": 1,
+						"size": 1.5
+					},
+					"enable": true,
+					"enableCustom": true,
+					"customPath": "jb2a.burrow.out.01.brown"
+				},
+				"between": {
+					"dbSection": "range",
+					"enable": true,
+					"menuType": "weapon",
+					"animation": "arrow",
+					"variant": "regular",
+					"color": "regular",
+					"options": {
+						"delay": 0,
+						"elevation": 800,
+						"opacity": 1,
+						"playbackRate": 1
+					},
+					"enableCustom": true,
+					"customPath": "jb2a.burrow.ranged.01.brown"
+				},
+				"end": {
+					"dbSection": "static",
+					"enabe": true,
+					"menuType": "spell",
+					"animation": "mistystep",
+					"variant": "02",
+					"color": "blue",
+					"options": {
+						"delay": 2500,
+						"elevation": 1000,
+						"fadeIn": 250,
+						"fadeOut": 250,
+						"isMasked": false,
+						"isRadius": false,
+						"opacity": 1,
+						"playbackRate": 1,
+						"size": 1.5
+					},
+					"enable": true,
+					"enableCustom": true,
+					"customPath": "jb2a.burrow.out.01.brown"
+				},
+				"options": {
+					"range": 30,
+					"hideFromPlayers": false,
+					"measureType": "alternating",
+					"teleport": true,
+					"speed": 120,
+					"delayMove": 2600,
+					"alpha": 0,
+					"delayFade": 750,
+					"delayReturn": 250,
+					"checkCollision": false
+				},
+				"sound": {
+					"enable": true,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-earth-moving-1.mp3"
+				}
+			},
+			"label": "Tunneler",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"menu": "preset",
+			"presetType": "teleportation",
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"metaData": {
+				"label": "Tunneler",
+				"menu": "preset",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836176
+			}
+		},
+		{
+			"id": "853",
 			"data": {
 				"video": {
 					"dbSection": "range",
@@ -178475,7 +179148,7 @@
 			}
 		},
 		{
-			"id": "850",
+			"id": "854",
 			"data": {
 				"projectile": {
 					"dbSection": "range",
@@ -178683,7 +179356,7 @@
 			}
 		},
 		{
-			"id": "851",
+			"id": "855",
 			"data": {
 				"video": {
 					"dbSection": "range",
@@ -178740,710 +179413,6 @@
 					"path": "",
 					"property": ""
 				}
-			}
-		},
-		{
-			"id": "852",
-			"data": {
-				"projectile": {
-					"dbSection": "range",
-					"menuType": "spell",
-					"animation": "fireballbeam",
-					"variant": "01",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": "",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"removeTemplate": false,
-						"wait": -1800
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 1,
-						"file": "psfx.3rd-level-spells.fireball.v1.001.beam"
-					}
-				},
-				"preExplosion": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1,
-						"wait": 0
-					},
-					"enable": false,
-					"sound": {
-						"enable": false,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75
-					}
-				},
-				"explosion": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "fireball",
-					"variant": "explode",
-					"color": "orange",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1.25,
-						"wait": -1000,
-						"aboveTemplate": false
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 1,
-						"file": "psfx.3rd-level-spells.fireball.v1.001.explosion"
-					}
-				},
-				"afterImage": {
-					"enable": false,
-					"customPath": "",
-					"options": {
-						"elevation": 0,
-						"persistent": false,
-						"scale": 1
-					}
-				}
-			},
-			"label": "Fireball",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "preset",
-			"presetType": "proToTemp",
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": true,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Fireball",
-				"menu": "preset",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "853",
-			"data": {
-				"projectile": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "snowball",
-					"variant": "01",
-					"color": "white",
-					"enableCustom": false,
-					"customPath": "",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 5,
-						"repeatDelay": 250,
-						"removeTemplate": false,
-						"wait": -1800
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75,
-						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-1.mp3"
-					}
-				},
-				"preExplosion": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1,
-						"wait": 0
-					},
-					"enable": false,
-					"sound": {
-						"enable": false,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75
-					}
-				},
-				"explosion": {
-					"dbSection": "static",
-					"menuType": "ice",
-					"animation": "snowflake",
-					"variant": "01",
-					"color": "whiteblue",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1.25,
-						"wait": -1000,
-						"aboveTemplate": false
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75,
-						"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-blast-1.mp3"
-					}
-				},
-				"afterImage": {
-					"enable": false,
-					"customPath": "",
-					"options": {
-						"elevation": 0,
-						"persistent": false,
-						"scale": 1
-					}
-				}
-			},
-			"label": "Snilloc's Snowball Swarm",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "preset",
-			"presetType": "proToTemp",
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": false,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Snilloc's Snowball Swarm",
-				"menu": "preset",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "854",
-			"data": {
-				"projectile": {
-					"dbSection": "range",
-					"menuType": "weapon",
-					"animation": "arrow",
-					"variant": "physical",
-					"color": "orange",
-					"enableCustom": true,
-					"customPath": "jb2a.ranged.card.01.projectile.01.yellow",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 30,
-						"repeatDelay": 125,
-						"removeTemplate": false,
-						"wait": 0,
-						"randomOffset": true
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 10,
-						"repeatDelay": 350,
-						"startTime": 500,
-						"volume": 0.75,
-						"file": "modules/dnd5e-animations/assets/sounds/Weapons/Ranged_Arrow_Impact/arrow-impact-7.mp3"
-					}
-				},
-				"preExplosion": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1,
-						"wait": 0
-					},
-					"enable": false,
-					"sound": {
-						"enable": false,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 0,
-						"volume": 0.75
-					}
-				},
-				"explosion": {
-					"dbSection": "static",
-					"menuType": "generic",
-					"animation": "impact",
-					"variant": "01",
-					"color": "orange",
-					"options": {
-						"elevation": 1000,
-						"opacity": 1,
-						"playbackRate": 1,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"scale": 1,
-						"wait": 0
-					},
-					"sound": {
-						"enable": true,
-						"delay": 0,
-						"repeat": 1,
-						"repeatDelay": 250,
-						"startTime": 500,
-						"volume": 0.75,
-						"file": "modules/dnd5e-animations/assets/sounds/Weapons/Ranged_Arrow_Impact/arrow-impact-7.mp3"
-					},
-					"enableCustom": true,
-					"customPath": "jb2a.ranged.card.01.projectile.01.yellow"
-				},
-				"afterImage": {
-					"enable": false,
-					"customPath": "",
-					"options": {
-						"elevation": 0,
-						"persistent": false,
-						"scale": 1
-					}
-				}
-			},
-			"label": "Spray of Cards",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "preset",
-			"presetType": "proToTemp",
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1.5,
-					"zIndex": 1
-				}
-			},
-			"target": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"opacity": 1,
-					"persistent": false,
-					"repeat": 10,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				}
-			},
-			"advanced": {
-				"exactMatch": false,
-				"excludedTerms": [],
-				"excludedType": {
-					"enabled": false,
-					"path": "",
-					"property": ""
-				}
-			},
-			"metaData": {
-				"label": "Spray of Cards",
-				"menu": "preset",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "855",
-			"data": {
-				"start": {
-					"dbSection": "static",
-					"enabe": true,
-					"menuType": "spell",
-					"animation": "mistystep",
-					"variant": "01",
-					"color": "blue",
-					"options": {
-						"delay": 0,
-						"elevation": 1000,
-						"fadeIn": 250,
-						"fadeOut": 250,
-						"isMasked": false,
-						"opacity": 1,
-						"isRadius": false,
-						"playbackRate": 1,
-						"size": 1.5
-					},
-					"enable": true,
-					"enableCustom": true,
-					"customPath": "jb2a.burrow.out.01.brown"
-				},
-				"between": {
-					"dbSection": "range",
-					"enable": true,
-					"menuType": "weapon",
-					"animation": "arrow",
-					"variant": "regular",
-					"color": "regular",
-					"options": {
-						"delay": 0,
-						"elevation": 800,
-						"opacity": 1,
-						"playbackRate": 1
-					},
-					"enableCustom": true,
-					"customPath": "jb2a.burrow.ranged.01.brown"
-				},
-				"end": {
-					"dbSection": "static",
-					"enabe": true,
-					"menuType": "spell",
-					"animation": "mistystep",
-					"variant": "02",
-					"color": "blue",
-					"options": {
-						"delay": 2500,
-						"elevation": 1000,
-						"fadeIn": 250,
-						"fadeOut": 250,
-						"isMasked": false,
-						"isRadius": false,
-						"opacity": 1,
-						"playbackRate": 1,
-						"size": 1.5
-					},
-					"enable": true,
-					"enableCustom": true,
-					"customPath": "jb2a.burrow.out.01.brown"
-				},
-				"options": {
-					"range": 30,
-					"hideFromPlayers": false,
-					"measureType": "alternating",
-					"teleport": true,
-					"speed": 120,
-					"delayMove": 2600,
-					"alpha": 0,
-					"delayFade": 750,
-					"delayReturn": 250,
-					"checkCollision": false
-				},
-				"sound": {
-					"enable": true,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-earth-moving-1.mp3"
-				}
-			},
-			"label": "Tunneler",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"menu": "preset",
-			"presetType": "teleportation",
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"metaData": {
-				"label": "Tunneler",
-				"menu": "preset",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
 			}
 		}
 	],
@@ -179587,6 +179556,753 @@
 		},
 		{
 			"id": "857",
+			"label": "Absorb Acid",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "green",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Acid",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "858",
+			"label": "Absorb Cold",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Cold",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "859",
+			"label": "Absorb Fire",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"saturation": 1,
+					"tintColor": "#ff0000",
+					"contrast": null
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Fire",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "860",
+			"label": "Absorb Lightning",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Lightning",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "861",
+			"label": "Absorb Thunder",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "marker",
+					"animation": "bubble",
+					"variant": "01",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"saturation": -1,
+					"contrast": 0.75
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Absorb Thunder",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "862",
 			"label": "Antilife Shell",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -179734,7 +180450,7 @@
 			}
 		},
 		{
-			"id": "858",
+			"id": "863",
 			"label": "Antimagic Field",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -179888,7 +180604,7 @@
 			}
 		},
 		{
-			"id": "859",
+			"id": "864",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
 			"secondary": {
@@ -180024,7 +180740,7 @@
 			}
 		},
 		{
-			"id": "860",
+			"id": "865",
 			"label": "Armor of Agathys",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -180180,9 +180896,9 @@
 			}
 		},
 		{
-			"id": "861",
-			"label": "Aura of ",
-			"activeEffectType": "aura",
+			"id": "866",
+			"label": "Aura of Alacricity",
+			"activeEffectType": "ontoken",
 			"menu": "aefx",
 			"macro": {
 				"enable": false,
@@ -180191,36 +180907,30 @@
 			"primary": {
 				"video": {
 					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "spiritguardians",
+					"menuType": "particles",
+					"animation": "swirl",
 					"variant": "01",
-					"color": "yellowblue",
-					"enableCustom": true,
-					"customPath": "jb2a.template_circle.aura.02.loop.large.yellow"
+					"color": "greenyellow",
+					"enableCustom": false,
+					"customPath": ""
 				},
 				"options": {
-					"addTokenWidth": true,
-					"alpha": false,
-					"alphaMax": 0.5,
-					"alphaMin": -0.5,
-					"alphaDuration": 1000,
-					"breath": false,
-					"breathMax": 1.05,
-					"breathMin": 0.95,
-					"breathDuration": 1000,
+					"addTokenWidth": false,
+					"anchor": "0.5",
 					"delay": 0,
 					"elevation": 1000,
 					"fadeIn": 250,
 					"fadeOut": 500,
+					"isMasked": false,
 					"isRadius": false,
 					"isWait": false,
-					"opacity": 0.25,
+					"opacity": 0.35,
+					"persistent": true,
 					"playbackRate": 1,
 					"playOn": "source",
-					"size": 7,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"tintSaturate": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
 					"unbindAlpha": false,
 					"unbindVisibility": false,
 					"zIndex": 1
@@ -180232,7 +180942,7 @@
 					"repeat": 1,
 					"repeatDelay": 250,
 					"startTime": 0,
-					"volume": 0.75
+					"volume": 0.35
 				}
 			},
 			"secondary": {
@@ -180325,18 +181035,27 @@
 					"zIndex": 1
 				}
 			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
 			"metaData": {
-				"label": "Aura of ",
+				"label": "Aura of Alacricity",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.1",
+				"version": "17421715611321"
 			}
 		},
 		{
-			"id": "862",
-			"label": "Aura of Annihilation",
-			"activeEffectType": "aura",
+			"id": "867",
+			"label": "Aura of Conquest",
+			"activeEffectType": "ontoken",
 			"menu": "aefx",
 			"macro": {
 				"enable": false,
@@ -180345,36 +181064,30 @@
 			"primary": {
 				"video": {
 					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "spiritguardians",
+					"menuType": "particles",
+					"animation": "swirl",
 					"variant": "01",
-					"color": "yellowblue",
-					"enableCustom": true,
-					"customPath": "jb2a.template_circle.aura.01.loop.large.bluepurple"
+					"color": "red",
+					"enableCustom": false,
+					"customPath": ""
 				},
 				"options": {
-					"addTokenWidth": true,
-					"alpha": false,
-					"alphaMax": 0.5,
-					"alphaMin": -0.5,
-					"alphaDuration": 1000,
-					"breath": false,
-					"breathMax": 1.05,
-					"breathMin": 0.95,
-					"breathDuration": 1000,
+					"addTokenWidth": false,
+					"anchor": "0.5",
 					"delay": 0,
 					"elevation": 1000,
 					"fadeIn": 250,
 					"fadeOut": 500,
+					"isMasked": false,
 					"isRadius": false,
 					"isWait": false,
-					"opacity": 0.25,
+					"opacity": 0.35,
+					"persistent": true,
 					"playbackRate": 1,
 					"playOn": "source",
-					"size": 7,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"tintSaturate": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
 					"unbindAlpha": false,
 					"unbindVisibility": false,
 					"zIndex": 1
@@ -180382,11 +181095,11 @@
 				"sound": {
 					"enable": true,
 					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Debuff/spell-whispers-1.mp3",
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
 					"repeat": 1,
 					"repeatDelay": 250,
 					"startTime": 0,
-					"volume": 0.75
+					"volume": 0.35
 				}
 			},
 			"secondary": {
@@ -180479,16 +181192,339 @@
 					"zIndex": 1
 				}
 			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
 			"metaData": {
-				"label": "Aura of Annihilation",
+				"label": "Aura of Conquest",
 				"menu": "aefx",
 				"name": "5e Animations",
-				"moduleVersion": "2.0.0",
-				"version": 1740566308510
+				"moduleVersion": "2.1.1",
+				"version": "17421715674521"
 			}
 		},
 		{
-			"id": "863",
+			"id": "868",
+			"label": "Aura of Courage",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "swirl",
+					"variant": "01",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.35,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.35
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Aura of Courage",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "174217157217211"
+			}
+		},
+		{
+			"id": "869",
+			"label": "Aura of Devotion",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "swirl",
+					"variant": "01",
+					"color": "purple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.35,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.35
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Aura of Devotion",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421715888331"
+			}
+		},
+		{
+			"id": "870",
 			"label": "Aura of Life",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -180642,7 +181678,164 @@
 			}
 		},
 		{
-			"id": "864",
+			"id": "871",
+			"label": "Aura of Protection",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "swirl",
+					"variant": "02",
+					"color": "white",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.35,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.35
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Aura of Protection",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421715938311"
+			}
+		},
+		{
+			"id": "872",
 			"label": "Aura of Purity",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -180796,7 +181989,321 @@
 			}
 		},
 		{
-			"id": "865",
+			"id": "873",
+			"label": "Aura of the Guardian",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "swirl",
+					"variant": "01",
+					"color": "white",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.35,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.35
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Aura of the Guardian",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421716098321"
+			}
+		},
+		{
+			"id": "874",
+			"label": "Aura of the Sentinel",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "swirl",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.35,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.35
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Aura of the Sentinel",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421716128151"
+			}
+		},
+		{
+			"id": "875",
 			"label": "Aura of Vitality",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -180950,7 +182457,164 @@
 			}
 		},
 		{
-			"id": "866",
+			"id": "876",
+			"label": "Aura of Warding",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "particles",
+					"animation": "swirl",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.35,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.35
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"advanced": {
+				"exactMatch": false,
+				"excludedTerms": [],
+				"excludedType": {
+					"enabled": false,
+					"path": "",
+					"property": ""
+				}
+			},
+			"metaData": {
+				"label": "Aura of Warding",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": "17421716181601"
+			}
+		},
+		{
+			"id": "877",
 			"label": "Avenging Angel",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181098,7 +182762,7 @@
 			}
 		},
 		{
-			"id": "867",
+			"id": "878",
 			"label": "Bane",
 			"menu": "aefx",
 			"secondary": {
@@ -181236,7 +182900,7 @@
 			}
 		},
 		{
-			"id": "868",
+			"id": "879",
 			"label": "Bardic Inspiration",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181383,7 +183047,7 @@
 			}
 		},
 		{
-			"id": "869",
+			"id": "880",
 			"label": "Barkskin",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181543,7 +183207,7 @@
 			}
 		},
 		{
-			"id": "870",
+			"id": "881",
 			"label": "Bastion of Law",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181691,7 +183355,7 @@
 			}
 		},
 		{
-			"id": "871",
+			"id": "882",
 			"label": "Blade Ward",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -181839,7 +183503,7 @@
 			}
 		},
 		{
-			"id": "872",
+			"id": "883",
 			"label": "Bless",
 			"menu": "aefx",
 			"macro": {
@@ -181978,7 +183642,7 @@
 			}
 		},
 		{
-			"id": "873",
+			"id": "884",
 			"label": "Blue Light",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182125,7 +183789,7 @@
 			}
 		},
 		{
-			"id": "874",
+			"id": "885",
 			"label": "Blur",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182282,7 +183946,7 @@
 			}
 		},
 		{
-			"id": "875",
+			"id": "886",
 			"label": "Charmed",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182429,7 +184093,7 @@
 			}
 		},
 		{
-			"id": "876",
+			"id": "887",
 			"label": "Chill Shield",
 			"menu": "aefx",
 			"primary": {
@@ -182571,7 +184235,7 @@
 			}
 		},
 		{
-			"id": "877",
+			"id": "888",
 			"label": "Circle of Power",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -182725,7 +184389,7 @@
 			}
 		},
 		{
-			"id": "878",
+			"id": "889",
 			"label": "Comic Dancing",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -182872,7 +184536,604 @@
 			}
 		},
 		{
-			"id": "879",
+			"id": "890",
+			"label": "Concentrating: Investiture of Flame",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "fire",
+					"variant": "03",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "red",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Flame",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "891",
+			"label": "Concentrating: Investiture of Ice",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "ice",
+					"variant": "03",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-2.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Ice",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "892",
+			"label": "Concentrating: Investiture of Stone",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "earth",
+					"variant": "03",
+					"color": "orange",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-earth-moving-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "yellow",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Stone",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "893",
+			"label": "Concentrating: Investiture of Wind",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "earth",
+					"variant": "01",
+					"color": "darkorange",
+					"enableCustom": true,
+					"customPath": "jb2a.template_circle.vortex.loop.dark_black"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.5,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1,
+					"tint": true,
+					"saturation": -1,
+					"tintColor": "#ffffff",
+					"contrast": 0.5
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-wind-gust-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "transmutation",
+					"variant": "complete",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0.5,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": true,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1,
+					"saturation": -1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Concentrating: Investiture of Wind",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "894",
 			"label": "Concentrating: Sunbeam",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183019,7 +185280,7 @@
 			}
 		},
 		{
-			"id": "880",
+			"id": "895",
 			"label": "Concentrating: Yolande's Regal Presence",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -183173,7 +185434,7 @@
 			}
 		},
 		{
-			"id": "881",
+			"id": "896",
 			"label": "Confused",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183329,7 +185590,7 @@
 			}
 		},
 		{
-			"id": "882",
+			"id": "897",
 			"label": "Conjure Woodland Beings",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -183483,7 +185744,7 @@
 			}
 		},
 		{
-			"id": "883",
+			"id": "898",
 			"label": "Conjured Minor Elementals",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -183637,7 +185898,7 @@
 			}
 		},
 		{
-			"id": "884",
+			"id": "899",
 			"label": "Contagion: Poison",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183788,7 +186049,7 @@
 			}
 		},
 		{
-			"id": "885",
+			"id": "900",
 			"label": "Control Water",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -183936,7 +186197,7 @@
 			}
 		},
 		{
-			"id": "886",
+			"id": "901",
 			"label": "Covered in Acid",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184083,7 +186344,7 @@
 			}
 		},
 		{
-			"id": "887",
+			"id": "902",
 			"label": "Crown of Madness: Charmed",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184231,7 +186492,7 @@
 			}
 		},
 		{
-			"id": "888",
+			"id": "903",
 			"label": "Crusader's Mantle",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -184385,7 +186646,7 @@
 			}
 		},
 		{
-			"id": "889",
+			"id": "904",
 			"label": "Detect Evil and Good",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -184539,7 +186800,7 @@
 			}
 		},
 		{
-			"id": "890",
+			"id": "905",
 			"label": "Detect Magic",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -184693,7 +186954,7 @@
 			}
 		},
 		{
-			"id": "891",
+			"id": "906",
 			"label": "Detect Poison and Disease",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -184847,7 +187108,7 @@
 			}
 		},
 		{
-			"id": "892",
+			"id": "907",
 			"label": "Diminish Defiance",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -184995,7 +187256,156 @@
 			}
 		},
 		{
-			"id": "893",
+			"id": "908",
+			"label": "Draconic Transformation",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "modules/dnd5e-animations/assets/graphics/DragonWings.webp"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5,0.65",
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 2,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Creatures/Growl/growl-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.aura_themed.01.outward.complete.metal.01.red"
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Draconic Transformation",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "909",
 			"label": "Dragon Wings",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185144,7 +187554,7 @@
 			}
 		},
 		{
-			"id": "894",
+			"id": "910",
 			"label": "Elemental Attunement",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185291,7 +187701,7 @@
 			}
 		},
 		{
-			"id": "895",
+			"id": "911",
 			"label": "Encased",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185439,7 +187849,7 @@
 			}
 		},
 		{
-			"id": "896",
+			"id": "912",
 			"label": "Ensnaring Strike: Restrained",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185586,7 +187996,7 @@
 			}
 		},
 		{
-			"id": "897",
+			"id": "913",
 			"label": "Entangle: Restrained",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185733,7 +188143,7 @@
 			}
 		},
 		{
-			"id": "898",
+			"id": "914",
 			"label": "Enthralled",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -185880,7 +188290,7 @@
 			}
 		},
 		{
-			"id": "899",
+			"id": "915",
 			"label": "Expeditious Retreat",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186027,7 +188437,7 @@
 			}
 		},
 		{
-			"id": "900",
+			"id": "916",
 			"label": "Fire Shield",
 			"menu": "aefx",
 			"primary": {
@@ -186169,7 +188579,7 @@
 			}
 		},
 		{
-			"id": "901",
+			"id": "917",
 			"label": "Flesh to Stone: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186316,7 +188726,7 @@
 			}
 		},
 		{
-			"id": "902",
+			"id": "918",
 			"label": "Glittering",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186463,7 +188873,7 @@
 			}
 		},
 		{
-			"id": "903",
+			"id": "919",
 			"label": "Green Light",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186610,7 +189020,7 @@
 			}
 		},
 		{
-			"id": "904",
+			"id": "920",
 			"label": "Haste",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186767,7 +189177,7 @@
 			}
 		},
 		{
-			"id": "905",
+			"id": "921",
 			"label": "Heat Metal: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -186915,7 +189325,7 @@
 			}
 		},
 		{
-			"id": "906",
+			"id": "922",
 			"label": "Hold Monster: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187062,7 +189472,7 @@
 			}
 		},
 		{
-			"id": "907",
+			"id": "923",
 			"label": "Hold Person: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187209,7 +189619,7 @@
 			}
 		},
 		{
-			"id": "908",
+			"id": "924",
 			"label": "Holy Aura (Aura)",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -187363,7 +189773,7 @@
 			}
 		},
 		{
-			"id": "909",
+			"id": "925",
 			"label": "Hypnotic Pattern: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187510,7 +189920,7 @@
 			}
 		},
 		{
-			"id": "910",
+			"id": "926",
 			"label": "Imprisonment: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187657,7 +190067,7 @@
 			}
 		},
 		{
-			"id": "911",
+			"id": "927",
 			"label": "Intellect Fortress",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187805,7 +190215,155 @@
 			}
 		},
 		{
-			"id": "912",
+			"id": "928",
+			"label": "Invulnerability",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "tokenborder",
+					"animation": "spinning",
+					"variant": "04",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-3.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": true,
+				"video": {
+					"dbSection": "static",
+					"menuType": "magicsign",
+					"animation": "abjuration",
+					"variant": "complete",
+					"color": "darkblue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 0,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 2,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Invulnerability",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "929",
 			"label": "Laughing Uncontrollably",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -187952,7 +190510,7 @@
 			}
 		},
 		{
-			"id": "913",
+			"id": "930",
 			"label": "Living Legend",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -188104,7 +190662,7 @@
 			}
 		},
 		{
-			"id": "914",
+			"id": "931",
 			"label": "Longstrider",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -188251,7 +190809,7 @@
 			}
 		},
 		{
-			"id": "915",
+			"id": "932",
 			"label": "Mage Armor",
 			"menu": "aefx",
 			"secondary": {
@@ -188389,7 +190947,7 @@
 			}
 		},
 		{
-			"id": "916",
+			"id": "933",
 			"label": "Mass Suggestion",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -188536,7 +191094,7 @@
 			}
 		},
 		{
-			"id": "917",
+			"id": "934",
 			"label": "Pass without Trace",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -188690,7 +191248,7 @@
 			}
 		},
 		{
-			"id": "918",
+			"id": "935",
 			"label": "Peerless Athlete",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -188838,7 +191396,155 @@
 			}
 		},
 		{
-			"id": "919",
+			"id": "936",
+			"label": "Primordial Ward",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "shieldfx",
+					"animation": "eldritchweb",
+					"variant": "01",
+					"color": "darkpurple",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 1,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": true,
+					"delay": 0,
+					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-barrier-1.mp3",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Primordial Ward",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "937",
 			"label": "Protection from Acid",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -188986,7 +191692,7 @@
 			}
 		},
 		{
-			"id": "920",
+			"id": "938",
 			"label": "Protection from Cold",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -189134,7 +191840,7 @@
 			}
 		},
 		{
-			"id": "921",
+			"id": "939",
 			"label": "Protection from Fire",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -189282,7 +191988,7 @@
 			}
 		},
 		{
-			"id": "922",
+			"id": "940",
 			"label": "Protection from Lightning",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -189430,7 +192136,7 @@
 			}
 		},
 		{
-			"id": "923",
+			"id": "941",
 			"label": "Protection from Thunder",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -189578,7 +192284,7 @@
 			}
 		},
 		{
-			"id": "924",
+			"id": "942",
 			"label": "Rage",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -189725,7 +192431,7 @@
 			}
 		},
 		{
-			"id": "925",
+			"id": "943",
 			"label": "Resistance: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -189873,7 +192579,7 @@
 			}
 		},
 		{
-			"id": "926",
+			"id": "944",
 			"label": "Shield",
 			"menu": "aefx",
 			"primary": {
@@ -190015,7 +192721,7 @@
 			}
 		},
 		{
-			"id": "927",
+			"id": "945",
 			"label": "Shield of Faith",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -190172,7 +192878,7 @@
 			}
 		},
 		{
-			"id": "928",
+			"id": "946",
 			"label": "Sleep: ",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -190319,7 +193025,7 @@
 			}
 		},
 		{
-			"id": "929",
+			"id": "947",
 			"label": "Slow",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -190476,7 +193182,7 @@
 			}
 		},
 		{
-			"id": "930",
+			"id": "948",
 			"label": "Spirit Guardians",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -190639,7 +193345,7 @@
 			}
 		},
 		{
-			"id": "931",
+			"id": "949",
 			"label": "Starry Form",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -190787,7 +193493,7 @@
 			}
 		},
 		{
-			"id": "932",
+			"id": "950",
 			"label": "Stonecunning: Tremorsense",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -190940,7 +193646,7 @@
 			}
 		},
 		{
-			"id": "933",
+			"id": "951",
 			"label": "Stoneskin",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -191088,7 +193794,7 @@
 			}
 		},
 		{
-			"id": "934",
+			"id": "952",
 			"label": "Suggestion",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -191244,7 +193950,7 @@
 			}
 		},
 		{
-			"id": "935",
+			"id": "953",
 			"label": "Surrounded by a Spirit Shroud",
 			"activeEffectType": "aura",
 			"menu": "aefx",
@@ -191398,7 +194104,7 @@
 			}
 		},
 		{
-			"id": "936",
+			"id": "954",
 			"label": "Synaptic Static: Muddled Thoughts",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -191545,7 +194251,7 @@
 			}
 		},
 		{
-			"id": "937",
+			"id": "955",
 			"label": "Unbreakable Majesty",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -191693,7 +194399,7 @@
 			}
 		},
 		{
-			"id": "938",
+			"id": "956",
 			"label": "Vicious Mockery",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -191840,7 +194546,7 @@
 			}
 		},
 		{
-			"id": "939",
+			"id": "957",
 			"label": "Violet Light",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -191987,7 +194693,7 @@
 			}
 		},
 		{
-			"id": "940",
+			"id": "958",
 			"label": "Warm Shield",
 			"menu": "aefx",
 			"primary": {
@@ -192129,7 +194835,154 @@
 			}
 		},
 		{
-			"id": "941",
+			"id": "959",
+			"label": "Wielding Shadow Blade",
+			"activeEffectType": "ontoken",
+			"menu": "aefx",
+			"macro": {
+				"enable": false,
+				"playWhen": "0"
+			},
+			"primary": {
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": true,
+					"customPath": "jb2a.spiritual_weapon.sword.dark.purple"
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": false,
+					"opacity": 0.75,
+					"persistent": true,
+					"playbackRate": 1,
+					"playOn": "source",
+					"repeat": 1,
+					"repeatDelay": 250,
+					"size": 1,
+					"unbindAlpha": false,
+					"unbindVisibility": false,
+					"zIndex": 1
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"secondary": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": true,
+					"isWait": false,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1.5,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"soundOnly": {
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				}
+			},
+			"source": {
+				"enable": false,
+				"video": {
+					"dbSection": "static",
+					"menuType": "spell",
+					"animation": "curewounds",
+					"variant": "01",
+					"color": "blue",
+					"enableCustom": false,
+					"customPath": ""
+				},
+				"sound": {
+					"enable": false,
+					"delay": 0,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"startTime": 0,
+					"volume": 0.75
+				},
+				"options": {
+					"addTokenWidth": false,
+					"anchor": "0.5",
+					"contrast": 0,
+					"delay": 0,
+					"elevation": 1000,
+					"fadeIn": 250,
+					"fadeOut": 500,
+					"isMasked": false,
+					"isRadius": false,
+					"isWait": true,
+					"opacity": 1,
+					"repeat": 1,
+					"repeatDelay": 250,
+					"saturate": 0,
+					"size": 1,
+					"tint": false,
+					"tintColor": "#FFFFFF",
+					"zIndex": 1
+				}
+			},
+			"metaData": {
+				"label": "Wielding Shadow Blade",
+				"menu": "aefx",
+				"name": "5e Animations",
+				"moduleVersion": "2.1.1",
+				"version": 1742171836177
+			}
+		},
+		{
+			"id": "960",
 			"label": "Wreathed in Moonlight",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -192279,7 +195132,7 @@
 			}
 		},
 		{
-			"id": "942",
+			"id": "961",
 			"label": "Yolande's Regal Presence: Prone",
 			"activeEffectType": "ontoken",
 			"menu": "aefx",
@@ -192427,1942 +195280,6 @@
 				"name": "5e Animations",
 				"moduleVersion": "2.0.0",
 				"version": 1740566308510
-			}
-		},
-		{
-			"id": "943",
-			"label": "Absorb Acid",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "bubble",
-					"variant": "01",
-					"color": "green",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Absorb Acid",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "944",
-			"label": "Absorb Cold",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "bubble",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Absorb Cold",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "945",
-			"label": "Absorb Fire",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "bubble",
-					"variant": "01",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"tint": true,
-					"saturation": 1,
-					"tintColor": "#ff0000",
-					"contrast": null
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Absorb Fire",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "946",
-			"label": "Absorb Lightning",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "bubble",
-					"variant": "01",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Absorb Lightning",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "947",
-			"label": "Absorb Thunder",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "marker",
-					"animation": "bubble",
-					"variant": "01",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"tint": true,
-					"saturation": -1,
-					"contrast": 0.75
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-4.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Absorb Thunder",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "948",
-			"label": "Concentrating: Investiture of Flame",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "fire",
-					"variant": "03",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Fire/fire-power-up-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "red",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Concentrating: Investiture of Flame",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "949",
-			"label": "Concentrating: Investiture of Ice",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "ice",
-					"variant": "03",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Damage/Ice/ice-whoomph-2.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Concentrating: Investiture of Ice",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "950",
-			"label": "Concentrating: Investiture of Stone",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "earth",
-					"variant": "03",
-					"color": "orange",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-earth-moving-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "yellow",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Concentrating: Investiture of Stone",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "951",
-			"label": "Concentrating: Investiture of Wind",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "earth",
-					"variant": "01",
-					"color": "darkorange",
-					"enableCustom": true,
-					"customPath": "jb2a.template_circle.vortex.loop.dark_black"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.5,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1,
-					"tint": true,
-					"saturation": -1,
-					"tintColor": "#ffffff",
-					"contrast": 0.5
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Elemental/spell-wind-gust-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "transmutation",
-					"variant": "complete",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0.5,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": true,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1,
-					"saturation": -1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Concentrating: Investiture of Wind",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "952",
-			"label": "Draconic Transformation",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "modules/dnd5e-animations/assets/graphics/DragonWings.webp"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5,0.65",
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 2,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Creatures/Growl/growl-3.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.aura_themed.01.outward.complete.metal.01.red"
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Hum/spell-hum-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Draconic Transformation",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "953",
-			"label": "Invulnerability",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "tokenborder",
-					"animation": "spinning",
-					"variant": "04",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-buff-build-up-3.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": true,
-				"video": {
-					"dbSection": "static",
-					"menuType": "magicsign",
-					"animation": "abjuration",
-					"variant": "complete",
-					"color": "darkblue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 0,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 2,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Invulnerability",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "954",
-			"label": "Primordial Ward",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "shieldfx",
-					"animation": "eldritchweb",
-					"variant": "01",
-					"color": "darkpurple",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 1,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": true,
-					"delay": 0,
-					"file": "modules/dnd5e-animations/assets/sounds/Spells/Buff/spell-barrier-1.mp3",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Primordial Ward",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
-			}
-		},
-		{
-			"id": "955",
-			"label": "Wielding Shadow Blade",
-			"activeEffectType": "ontoken",
-			"menu": "aefx",
-			"macro": {
-				"enable": false,
-				"playWhen": "0"
-			},
-			"primary": {
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": true,
-					"customPath": "jb2a.spiritual_weapon.sword.dark.purple"
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": false,
-					"opacity": 0.75,
-					"persistent": true,
-					"playbackRate": 1,
-					"playOn": "source",
-					"repeat": 1,
-					"repeatDelay": 250,
-					"size": 1,
-					"unbindAlpha": false,
-					"unbindVisibility": false,
-					"zIndex": 1
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"secondary": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": true,
-					"isWait": false,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1.5,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"soundOnly": {
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				}
-			},
-			"source": {
-				"enable": false,
-				"video": {
-					"dbSection": "static",
-					"menuType": "spell",
-					"animation": "curewounds",
-					"variant": "01",
-					"color": "blue",
-					"enableCustom": false,
-					"customPath": ""
-				},
-				"sound": {
-					"enable": false,
-					"delay": 0,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"startTime": 0,
-					"volume": 0.75
-				},
-				"options": {
-					"addTokenWidth": false,
-					"anchor": "0.5",
-					"contrast": 0,
-					"delay": 0,
-					"elevation": 1000,
-					"fadeIn": 250,
-					"fadeOut": 500,
-					"isMasked": false,
-					"isRadius": false,
-					"isWait": true,
-					"opacity": 1,
-					"repeat": 1,
-					"repeatDelay": 250,
-					"saturate": 0,
-					"size": 1,
-					"tint": false,
-					"tintColor": "#FFFFFF",
-					"zIndex": 1
-				}
-			},
-			"metaData": {
-				"label": "Wielding Shadow Blade",
-				"menu": "aefx",
-				"name": "5e Animations",
-				"moduleVersion": "2.1.0",
-				"version": 1741827752760
 			}
 		}
 	],


### PR DESCRIPTION
This version focuses on updating Paladin auras. It was pointed out that when aura active effects were applied with a module like Cauldron of Plentiful Resources (CPR), they also applied to multiple nearby actors and it looked very distracting. Honestly, even if it only applied to one actor, it's a bit much anyway. So I made the animations more subtle, adding just a bit of a sparkle effect that's visible on the Paladin and the actors affected by their auras.

There is now a specified animation configuration for each Paladin aura I could find. Previously, there was an animation called **"Aura of" meant to apply to multiple auras. That's now gone, but since it was missing metadata, it won't delete automatically. I suggest you delete it manually if it's causing issues.**

Since that didn't seem to have metadata, I reviewed other configurations and noticed several others were also missing it. You may therefore see several changes and additions upon update, but really it's just the addition of metadata to existing entries. This metadata helps the module track which configurations actually need updates, using a more intelligent system than the built-in Automated Animation options of merging or overwriting settings. The only other change was the removal of an old animation that had "-disable" at the end, which I'd forgotten to remove earlier, so all-in-all, it's just a small update this time.

There is one other animation that's disabled in the same way, Heal. This is because there's an activity named Heal that's on most healing spells, which also triggers that animation. So I had two choices: either all healing animations would share the same animation, or Heal would have no animation. For now, I've chosen for Heal to have no animation. I'm hoping to fix that in the future, but right now, it's a limitation of how the D&D 5e system 4.X.X is handled in Automated Animations. If this subject interests you, stay tuned!